### PR TITLE
Fix: Transform AI-generated node data to prevent rendering crash

### DIFF
--- a/src/components/ChatWindow.tsx
+++ b/src/components/ChatWindow.tsx
@@ -81,14 +81,33 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({ onClose, onFlowchartGene
       // New logic: If it's structured data, parse it and call the callback
       if (data.isStructuredData && data.response) {
         try {
-          const flowchartJSON = JSON.parse(data.response);
-          // Basic validation that it has nodes and edges (which are arrays)
-          if (flowchartJSON && Array.isArray(flowchartJSON.nodes) && Array.isArray(flowchartJSON.edges)) {
-            // Type assertion might be needed if TS complains, or more robust validation
-            onFlowchartGenerated(flowchartJSON as FlowchartData);
-            console.log("ChatWindow: Sent structured flowchart data to App.tsx");
+          // Assuming AI sends nodes as: { id: string, label: string, type: string, position: {x: number, y: number} }
+          // And edges as: { id: string, source: string, target: string }
+          const aiOutput = JSON.parse(data.response);
+
+          if (aiOutput && Array.isArray(aiOutput.nodes) && Array.isArray(aiOutput.edges)) {
+            // Transform nodes to meet the FlowchartNode structure, specifically the data.label part
+            const transformedNodes = aiOutput.nodes.map((node: any) => ({
+              id: node.id,
+              type: node.type,
+              position: node.position,
+              // Create the nested 'data' object with 'label'
+              data: {
+                label: node.label,
+                // value and condition will be undefined, which is fine as they are optional in FlowchartNodeData
+              },
+            }));
+
+            // Create the transformed FlowchartData object
+            const transformedFlowchartData: FlowchartData = {
+              nodes: transformedNodes,
+              edges: aiOutput.edges, // Edges structure from AI should be compatible
+            };
+
+            onFlowchartGenerated(transformedFlowchartData);
+            console.log("ChatWindow: Sent transformed structured flowchart data to App.tsx", transformedFlowchartData);
           } else {
-            console.warn("ChatWindow: Received structured data flag, but content was not valid FlowchartData:", flowchartJSON);
+            console.warn("ChatWindow: Received structured data flag from AI, but content was not in expected {nodes: [], edges: []} format:", aiOutput);
           }
         } catch (parseError) {
           console.error("ChatWindow: Failed to parse structured flowchart data from AI:", parseError, data.response);


### PR DESCRIPTION
This pull request updates the `ChatWindow` component to improve the handling and transformation of structured flowchart data received from the AI. The changes ensure compatibility with the `FlowchartData` structure by transforming the nodes into the required format and maintaining robust error handling.

### Improvements to structured data handling:

* [`src/components/ChatWindow.tsx`](diffhunk://#diff-dfda5eea96eeab3d46f6de06b6226689093411527b740bf85eb92956b7b46e8aL84-R110): Enhanced the parsing and transformation logic for structured flowchart data. Nodes are now transformed to include a nested `data` object with a `label`, ensuring compatibility with the `FlowchartNode` structure. This change improves integration with the application's flowchart rendering functionality.

* [`src/components/ChatWindow.tsx`](diffhunk://#diff-dfda5eea96eeab3d46f6de06b6226689093411527b740bf85eb92956b7b46e8aL84-R110): Updated error messages to clarify when the received structured data from the AI does not match the expected `{nodes: [], edges: []}` format, improving debugging and traceability.This commit addresses a frontend crash that occurred when attempting to render AI-generated flowcharts. The crash was due to a mismatch between the node structure provided by the AI and the structure expected by `FlowchartBuilder.tsx`.

The AI provided nodes as:
`{ id: "...", label: "...", type: "...", position: {...} }`

While `FlowchartBuilder.tsx` (and its underlying library) expects the label (and other custom data) to be within a nested `data` object: `{ id: "...", data: { label: "..." }, type: "...", position: {...} }`

Changes:
- Modified `src/components/ChatWindow.tsx` in the `handleSendMessage` function.
- When structured flowchart data is received from the backend for a `/generate` command, the `nodes` array is now transformed.
- Each node from the AI has its `label` property moved into a nested `data` object (e.g., `data: { label: node.label }`).
- The rest of the node properties (`id`, `type`, `position`) and the `edges` array are preserved as is.

This transformation ensures that the `FlowchartData` object passed to `App.tsx` and subsequently to `FlowchartBuilder.tsx` conforms to the expected data structure, preventing the TypeError that caused the application to crash.