### PR TITLE
feat: Integrate Firebase Authentication for Google Sign-In

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -5,6 +5,9 @@ import os
 import google.generativeai as genai
 import json
 from dotenv import load_dotenv # <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< IMPORT THIS
+import firebase_admin
+from firebase_admin import credentials, auth
+from typing import Optional # Added for Optional email in FirebaseUser
 
 # --- .env DEBUG START ---
 print("DEBUG: Script starting. Attempting to load .env file...")
@@ -26,6 +29,21 @@ if retrieved_api_key_immediately:
 else:
     print("DEBUG: GEMINI_API_KEY is NOT in os.environ immediately after load_dotenv() attempt.")
 # --- .env DEBUG END ---
+
+# Firebase Admin SDK Initialization
+try:
+    cred_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+    if not cred_path:
+        print("WARNING: GOOGLE_APPLICATION_CREDENTIALS environment variable not set. Firebase Admin SDK will not be initialized.")
+        # Or raise an error if Firebase is critical for the app to start
+    elif not os.path.exists(cred_path): # Check if the path actually exists
+        print(f"ERROR: Firebase credentials file not found at path: {cred_path}. Firebase Admin SDK will not be initialized.")
+    else:
+        cred = credentials.Certificate(cred_path)
+        firebase_admin.initialize_app(cred)
+        print("INFO: Firebase Admin SDK initialized successfully.")
+except Exception as e:
+    print(f"ERROR: Failed to initialize Firebase Admin SDK: {e}")
 
 app = FastAPI()
 
@@ -126,6 +144,13 @@ class UserDetails(BaseModel):
     points: int
     tasks_completed: List[str]
 
+class IdToken(BaseModel):
+    token: str
+
+class FirebaseUser(BaseModel):
+    uid: str
+    email: Optional[str] = None
+
 @app.get("/")
 async def read_root():
     status = "Gemini Configured and Model Initialized" if model else "Gemini NOT Configured or Model Init Failed - Check Logs & .env setup"
@@ -201,11 +226,23 @@ async def handle_chat_message(chat_message: ChatMessage):
     return {"response": response_text, "isStructuredData": is_structured_data}
 
 
-@app.post("/auth/google")
-async def auth_google_signin():
-    # This is a placeholder for the OAuth initiation
-    # In a real scenario, this would redirect the user to Google's OAuth consent screen
-    return {"message": "Google Sign-In initiated (placeholder)"}
+@app.post("/auth/google", response_model=FirebaseUser)
+async def auth_google_signin(id_token_body: IdToken):
+    token_string = id_token_body.token
+    try:
+        # Note: verify_id_token is synchronous.
+        # If this becomes a performance bottleneck, consider running it in a thread pool:
+        # from fastapi.concurrency import run_in_threadpool
+        # decoded_token = await run_in_threadpool(auth.verify_id_token, token_string)
+        decoded_token = auth.verify_id_token(token_string)
+        uid = decoded_token['uid']
+        email = decoded_token.get('email')
+        # Here you would typically create or update the user in your database
+        return FirebaseUser(uid=uid, email=email)
+    except firebase_admin.auth.InvalidIdTokenError as e:
+        raise HTTPException(status_code=401, detail=f"Invalid ID token: {e}")
+    except Exception as e: # Catch other potential errors during token verification
+        raise HTTPException(status_code=401, detail=f"Token verification failed: {e}")
 
 
 @app.get("/users/{user_id}/details", response_model=UserDetails)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,4 @@ google-generativeai>=0.3.0
 python-dotenv>=0.21.0
 google-auth>=2.0.0
 httpx>=0.20.0 # For TestClient
+firebase-admin>=6.0.0

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -1,13 +1,68 @@
 from fastapi.testclient import TestClient
-from main import app # Assuming your FastAPI app instance is named 'app' in main.py
+from unittest.mock import patch
+import firebase_admin # Import the base module to mock auth
+from firebase_admin import auth # Specifically for InvalidIdTokenError if needed directly
+
+# Import your FastAPI app
+# Ensure that main.py and particularly the Firebase Admin SDK initialization
+# is safe to run multiple times or is guarded (e.g., if firebase_admin.get_app() check)
+# For testing, it's common to have a fixture that initializes Firebase once.
+# However, given the current structure, we'll proceed assuming main.py handles this.
+from main import app
 
 client = TestClient(app)
 
-def test_google_signin():
-    response = client.post("/auth/google")
-    assert response.status_code == 200
-    assert response.json() == {"message": "Google Sign-In initiated (placeholder)"}
+# Mock Firebase credentials path for testing if not already handled by environment
+# This might be necessary if main.py's Firebase init depends on it and it's not set in test env
+# For example:
+# import os
+# os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = "path/to/mock/credentials.json"
+# Ensure this mock file exists or the init code in main.py can handle its absence gracefully for tests.
+# For now, we assume main.py's error handling for Firebase init is sufficient for tests to run.
 
+# It's good practice to ensure Firebase is initialized for tests that need it.
+# If main.py doesn't initialize it because GOOGLE_APPLICATION_CREDENTIALS is not set,
+# tests relying on firebase_admin.auth calls (even mocked) might fail if the
+# auth module itself isn't available due to a failed initial firebase_admin.initialize_app().
+# A more robust setup might involve a conftest.py to initialize Firebase for the test suite.
+
+@patch('firebase_admin.auth.verify_id_token')
+def test_auth_google_success(mock_verify_id_token):
+    # Configure the mock to return a dictionary representing a decoded token
+    mock_verify_id_token.return_value = {'uid': 'testuid123', 'email': 'test@example.com'}
+
+    response = client.post("/auth/google", json={"token": "dummy_token_string"})
+
+    assert response.status_code == 200
+    assert response.json() == {"uid": "testuid123", "email": "test@example.com"}
+    mock_verify_id_token.assert_called_once_with("dummy_token_string")
+
+@patch('firebase_admin.auth.verify_id_token')
+def test_auth_google_invalid_token(mock_verify_id_token):
+    # Configure the mock to raise firebase_admin.auth.InvalidIdTokenError
+    # Note: Ensure firebase_admin.auth is imported if you need to reference InvalidIdTokenError directly.
+    # If main.py imports firebase_admin.auth, it should be available.
+    # We are mocking 'firebase_admin.auth.verify_id_token', so the exception should be
+    # available in the scope where firebase_admin.auth is used (i.e., main.py)
+    mock_verify_id_token.side_effect = auth.InvalidIdTokenError("Invalid token")
+
+
+    response = client.post("/auth/google", json={"token": "invalid_dummy_token"})
+
+    assert response.status_code == 401
+    assert "detail" in response.json()
+    # Optionally, check the content of the detail message
+    assert "Invalid ID token" in response.json()["detail"]
+    mock_verify_id_token.assert_called_once_with("invalid_dummy_token")
+
+def test_auth_google_missing_token():
+    response = client.post("/auth/google", json={}) # Empty JSON body
+    assert response.status_code == 422 # Unprocessable Entity for Pydantic validation error
+
+    response_no_token_field = client.post("/auth/google", json={"not_token": "some_value"})
+    assert response_no_token_field.status_code == 422
+
+# Test for the /users/{user_id}/details endpoint (remains unchanged but kept for completeness)
 def test_get_user_details():
     response = client.get("/users/testuser/details")
     assert response.status_code == 200
@@ -16,5 +71,4 @@ def test_get_user_details():
     assert "points" in data
     assert "tasks_completed" in data
     assert isinstance(data["points"], int)
-    # Optionally, assert the mock point value if it's stable
     assert data["points"] == 100


### PR DESCRIPTION
This pull request introduces Firebase authentication to the backend, including the initialization of the Firebase Admin SDK, the addition of new models for handling Firebase user data, and updates to the `/auth/google` endpoint to verify ID tokens. It also includes new tests to validate the authentication functionality. Below is a summary of the most important changes:

### Firebase Integration

* **Firebase Admin SDK Initialization**: Added initialization logic for the Firebase Admin SDK in `backend/main.py`, including environment variable checks for credentials and error handling for initialization failures.
* **New Models for Firebase User Data**: Introduced `IdToken` and `FirebaseUser` models in `backend/main.py` to represent ID tokens and Firebase user data, respectively.

### Authentication Endpoint Updates

* **Updated `/auth/google` Endpoint**: Replaced the placeholder Google Sign-In endpoint with a new implementation that verifies Firebase ID tokens and returns user data (`uid` and `email`). Added error handling for invalid or missing tokens.

### Testing Enhancements

* **Unit Tests for `/auth/google` Endpoint**: Added tests in `backend/test_main.py` to validate the `/auth/google` endpoint, including successful token verification, handling of invalid tokens, and validation errors for missing tokens. Mocked Firebase Admin SDK's `verify_id_token` for testing purposes.

### Dependency Updates

* **Added Firebase Admin SDK to Dependencies**: Updated `backend/requirements.txt` to include `firebase-admin>=6.0.0`.This commit revamps the Google Sign-In functionality to use Firebase Authentication.

Key changes:
- Added `firebase-admin` to backend dependencies.
- Configured Firebase Admin SDK initialization in `backend/main.py` using the `GOOGLE_APPLICATION_CREDENTIALS` environment variable for service account key.
- Modified the `/auth/google` (POST) endpoint:
    - Expects a Firebase ID token in the request body (`{"token": "id_token_string"}`).
    - Verifies the ID token using `firebase_admin.auth.verify_id_token()`.
    - On success, returns your Firebase UID and email.
    - On failure (invalid/expired token), returns a 401 Unauthorized error.
- Defined Pydantic models `IdToken` (for request) and `FirebaseUser` (for response).
- The `/users/{user_id}/details` endpoint remains, with `user_id` intended to be the Firebase UID. It continues to serve mock data for now.
- Updated tests in `backend/test_main.py` for the `/auth/google` endpoint:
    - Mocked `firebase_admin.auth.verify_id_token` to test success and failure scenarios.
    - Added tests for invalid request bodies (missing token).
    - Removed the previous placeholder test for Google Sign-In.

The frontend will need to be updated to use the Firebase client SDK to obtain an ID token and send it to this new backend endpoint. The `GOOGLE_APPLICATION_CREDENTIALS` environment variable must be set in the backend environment for Firebase Admin to initialize correctly.