### PR TITLE
feat: Implement horizontal collapse/expand for InputOutput section

### DIFF
--- a/src/components/InputOutput.tsx
+++ b/src/components/InputOutput.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Exercise, ExecutionResult } from '../types/index';
-import { CheckCircle, XCircle, Clock, AlertTriangle, ChevronUp, ChevronDown } from 'lucide-react'; // Import ChevronUp and ChevronDown
+import { CheckCircle, XCircle, Clock, AlertTriangle, ChevronLeft, ChevronRight, ChevronUp, ChevronDown } from 'lucide-react'; // Import ChevronUp and ChevronDown
 
 interface InputOutputProps {
   exercise: Exercise;
@@ -16,7 +16,10 @@ export const InputOutput: React.FC<InputOutputProps> = ({
   const [isContentVisible, setIsContentVisible] = useState(true); // Default to true (expanded)
 
   return (
-    <div className="w-96 bg-white border-l border-gray-200 flex flex-col h-full">
+    <div className={`
+      bg-white border-gray-200 flex flex-col h-full transition-all duration-300 ease-in-out
+      ${isContentVisible ? 'w-96 border-l' : 'w-0 border-l-0 overflow-hidden'}
+    `}>
       {/* Header */}
       <div className="p-4 sm:p-6 border-b border-gray-200"> {/* Adjusted padding for consistency */}
         <div className="flex justify-between items-center mb-1 sm:mb-2"> {/* Reduced mb for tighter look */}
@@ -27,7 +30,7 @@ export const InputOutput: React.FC<InputOutputProps> = ({
             aria-label={isContentVisible ? "Collapse section" : "Expand section"}
             title={isContentVisible ? "Collapse section" : "Expand section"}
           >
-            {isContentVisible ? <ChevronUp size={20} /> : <ChevronDown size={20} />}
+            {isContentVisible ? <ChevronLeft size={20} /> : <ChevronRight size={20} />}
           </button>
         </div>
         {isContentVisible && ( // Conditionally render the description
@@ -41,7 +44,7 @@ export const InputOutput: React.FC<InputOutputProps> = ({
       <div
         className={`
           transition-all duration-300 ease-in-out overflow-hidden
-          ${isContentVisible ? 'max-h-[1500px] opacity-100' : 'max-h-0 opacity-0'}
+          ${isContentVisible ? 'max-w-[500px] opacity-100' : 'max-w-0 opacity-0'}
         `}
       >
         {/* Input Section */}


### PR DESCRIPTION
I've refactored the InputOutput component to use a horizontal (width-based) animation for showing and hiding the panel, instead of the previous vertical (height-based) animation.

Changes include:
- Modified Tailwind CSS classes in `InputOutput.tsx` to transition `max-width` and `width` properties.
- Updated collapse/expand icons from Chevrons Up/Down to Chevrons Left/Right for better affordance of horizontal movement.
- Ensured `overflow-hidden` is applied during collapse to prevent content spill.
- Adjusted border visibility to match the collapsed/expanded states.

This change allows the Input/Output panel to be hidden off to the side, potentially allowing other UI elements to take up more horizontal space as per your request.