### PR TITLE
feat: Use environment variable for backend API URL

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -44,7 +44,9 @@ export const AuthProvider: React.FC<{children: ReactNode}> = ({ children }) => {
         const idToken = await firebaseUser.getIdToken();
         // TODO: Adjust the fetch URL if your backend is on a different port/domain
         // e.g., http://localhost:8000/api/auth/google
-        const response = await fetch('/api/auth/google', {
+        const apiBaseUrl = import.meta.env.VITE_API_BASE_URL || ''; // Fallback to empty for same-origin or proxy
+        const endpoint = `${apiBaseUrl}/api/auth/google`;
+        const response = await fetch(endpoint, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',


### PR DESCRIPTION
Modified `src/contexts/AuthContext.tsx` to use the `VITE_API_BASE_URL` environment variable to define the base URL for API calls. This allows the backend URL to be configured dynamically for different environments (development, production) without code changes.

The call to `/api/auth/google` now prepends the value of `VITE_API_BASE_URL`. A fallback to an empty string is included, which maintains the previous behavior of using a relative path if the environment variable is not set (useful for local proxy setups).