### PR TITLE
Revert: Remove 'Modes' menu from Header and App state

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,7 +41,6 @@ function App() {
     width: window.innerWidth,
     height: window.innerHeight,
   });
-  const [currentAppMode, setCurrentAppMode] = useState<'normal' | 'learn' | 'generate'>('normal');
 
   // Guide State
   const [isGuideOpen, setIsGuideOpen] = useState(false);
@@ -370,14 +369,10 @@ function App() {
     }
   }, [showConfetti]);
 
-  useEffect(() => {
-    console.log("App mode changed to:", currentAppMode);
-  }, [currentAppMode]);
-
   return (
     <div className="min-h-screen bg-gray-50 flex flex-col relative"> {/* Added relative */}
       {showConfetti && <Confetti width={windowSize.width} height={windowSize.height} recycle={false} />} {/* recycle={false} makes it a one-shot burst */}
-      <Header progress={progress} onOpenGuide={handleOpenGuide} onSetAppMode={setCurrentAppMode} />
+      <Header progress={progress} onOpenGuide={handleOpenGuide} />
       
       <div className="flex-1 flex overflow-hidden"> {/* Added overflow-hidden for safety */}
         {/* Left Panel Toggle & Exercise List */}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { StudentProgress } from '../types'; // Ensure this path is correct
 import { User, Trophy, Target, Clock, HelpCircle } from 'lucide-react'; // Added HelpCircle
 import { useAuth } from '../contexts/AuthContext';
@@ -6,12 +6,10 @@ import { useAuth } from '../contexts/AuthContext';
 interface HeaderProps {
   progress: StudentProgress;
   onOpenGuide: () => void; // Added prop for opening guide
-  onSetAppMode: (mode: 'normal' | 'learn' | 'generate') => void; // New prop
 }
 
-export const Header: React.FC<HeaderProps> = ({ progress, onOpenGuide, onSetAppMode }) => {
+export const Header: React.FC<HeaderProps> = ({ progress, onOpenGuide }) => {
   const { currentUser, signInWithGoogle, signOut, loading } = useAuth();
-  const [isModesMenuOpen, setIsModesMenuOpen] = useState(false);
 
   return (
     <header className="bg-white border-b border-gray-200 px-4 sm:px-6 py-3"> {/* Adjusted padding for smaller screens */}
@@ -90,48 +88,6 @@ export const Header: React.FC<HeaderProps> = ({ progress, onOpenGuide, onSetAppM
                 Sign in with Google
               </button>
             )}
-
-            <div className="relative"> {/* Needed for dropdown positioning later */}
-              <button
-                onClick={() => setIsModesMenuOpen(!isModesMenuOpen)}
-                className={`font-medium py-1.5 px-2 sm:py-2 sm:px-3 rounded text-xs sm:text-sm transition-colors duration-150 ${
-                  isModesMenuOpen
-                    ? 'bg-blue-100 text-blue-700' // Style when open
-                    : 'text-gray-500 hover:bg-blue-100 hover:text-blue-600' // Style when closed
-                }`}
-                title="Select Mode"
-              >
-                Modes
-              </button>
-              {isModesMenuOpen && (
-                <div className="absolute right-0 top-full mt-2 w-48 bg-white border border-gray-200 rounded-md shadow-lg py-1 z-50">
-                  <a
-                    href="#"
-                    onClick={(e) => {
-                      e.preventDefault();
-                      console.log('Learn by Topic clicked');
-                      onSetAppMode('learn'); // Set app mode
-                      setIsModesMenuOpen(false);
-                    }}
-                    className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 hover:text-gray-900"
-                  >
-                    Learn by Topic
-                  </a>
-                  <a
-                    href="#"
-                    onClick={(e) => {
-                      e.preventDefault();
-                      console.log('Generate by Name clicked');
-                      onSetAppMode('generate'); // Set app mode
-                      setIsModesMenuOpen(false);
-                    }}
-                    className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 hover:text-gray-900"
-                  >
-                    Generate by Name
-                  </a>
-                </div>
-              )}
-            </div>
 
             <button
               onClick={onOpenGuide}


### PR DESCRIPTION
This commit reverts the changes introduced in commit `feat/modes-menu-part1`. The 'Modes' menu and associated application mode state (`currentAppMode`) have been removed from `Header.tsx` and `App.tsx` respectively.

This is a preparatory step to re-implement the 'Modes' menu feature in the correct location (within the ChatWindow component) as per clarified requirements.