### PR TITLE
fix: Improve InputOutput panel collapse visibility (GH-29)

### DIFF
--- a/src/components/InputOutput.tsx
+++ b/src/components/InputOutput.tsx
@@ -18,19 +18,19 @@ export const InputOutput: React.FC<InputOutputProps> = ({
   return (
     <div className={`
       bg-white border-gray-200 flex flex-col h-full transition-all duration-300 ease-in-out
-      ${isContentVisible ? 'w-96 border-l' : 'w-0 border-l-0 overflow-hidden'}
+      ${isContentVisible ? 'w-96 border-l' : 'w-12 border-l overflow-hidden'}
     `}>
       {/* Header */}
-      <div className="p-4 sm:p-6 border-b border-gray-200"> {/* Adjusted padding for consistency */}
-        <div className="flex justify-between items-center mb-1 sm:mb-2"> {/* Reduced mb for tighter look */}
-          <h3 className="text-md sm:text-lg font-semibold text-gray-900">Input & Output</h3>
+      <div className={`border-gray-200 ${isContentVisible ? 'p-4 sm:p-6 border-b' : 'p-0 w-full h-full flex items-center justify-center'}`}>
+        <div className={`flex items-center ${isContentVisible ? 'justify-between mb-1 sm:mb-2' : 'justify-center w-full'}`}>
+          {isContentVisible && <h3 className="text-md sm:text-lg font-semibold text-gray-900">Input & Output</h3>}
           <button
             onClick={() => setIsContentVisible(!isContentVisible)}
-            className="p-1 rounded-md hover:bg-gray-100 text-gray-500 hover:text-gray-700 transition-colors"
+            className={`p-1 rounded-md transition-colors ${isContentVisible ? 'text-gray-500 hover:text-gray-700 hover:bg-gray-100' : 'text-gray-700 hover:text-blue-600 w-full h-full flex items-center justify-center bg-gray-100 hover:bg-gray-200'}`}
             aria-label={isContentVisible ? "Collapse section" : "Expand section"}
             title={isContentVisible ? "Collapse section" : "Expand section"}
           >
-            {isContentVisible ? <ChevronLeft size={20} /> : <ChevronRight size={20} />}
+            {isContentVisible ? <ChevronLeft size={20} /> : <ChevronRight size={24} />}
           </button>
         </div>
         {isContentVisible && ( // Conditionally render the description


### PR DESCRIPTION
Addresses issue #29 where the horizontally collapsed Input/Output panel was too hidden for new users.

Changes in `src/components/InputOutput.tsx`:
- Modified the internal collapsed state (when `isContentVisible` is false):
    - The main component div now collapses to a `w-12` (48px) width with a left border, forming a visible vertical tab, instead of `w-0`.
    - `overflow-hidden` is maintained on this tab.
- Adjusted the internal header of the `InputOutput` component:
    - When collapsed to the `w-12` tab, the "Input & Output" title and the descriptive paragraph are hidden.
    - The toggle button (Chevron icon) is centered within the tab and remains the primary interaction point.
    - The expand icon (ChevronRight) is made slightly larger for better visibility within the tab.
    - The button's background in the tab state is styled for clarity.
- The inner content area (containing sample inputs/outputs) continues to use `max-w-0` and `opacity-0` to ensure it's fully hidden within the collapsed tab.

This change makes the minimized Input/Output panel more discoverable and user-friendly, as it's clear that the panel is still accessible and can be expanded.