### PR TITLE
feat: Make Input/Output panel sticky

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -474,7 +474,7 @@ function App() {
 
         {/* Right Panel Toggle & Input/Output Panel */}
         {currentExercise && ( // Only show if an exercise is selected
-          <div className="flex"> {/* Container for toggle and panel */}
+          <div className="flex h-full sticky top-0"> {/* Apply sticky classes here */}
             {isInputOutputOpen && (
               <InputOutput
                 exercise={currentExercise} // currentExercise will not be null here


### PR DESCRIPTION
Implements sticky positioning for the Input/Output panel section in `App.tsx`. This ensures that the I/O panel and its main toggle button remain visible at the top of their container when the main content area is scrolled.

Changes:
- In `App.tsx`, the `div` wrapping the `InputOutput` component and its toggle button has been updated with Tailwind CSS classes `h-full sticky top-0` to enable this behavior.

This improves the accessibility of the Input/Output panel, especially on pages with long, scrollable content.