### PR TITLE
fix: Adjust flowchart dot pattern color to light blue

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -3,7 +3,7 @@
 @tailwind utilities;
 
 .flowchart-dots-bg {
-  background-image: radial-gradient(circle, #cccccc 1px, rgba(0,0,0,0) 1px);
+  background-image: radial-gradient(circle, #E0F2FE 1px, rgba(0,0,0,0) 1px);
   background-size: 16px 16px;
   /* You might want to set a base background-color for the canvas itself,
      if it's not already white or another desired color from its parent.


### PR DESCRIPTION
Updates the color of the dot pattern background in the FlowchartBuilder canvas to a lighter, more subtle blue.

Changes:
- In `src/index.css`, modified the `.flowchart-dots-bg` class:
    - The `background-image` radial gradient for the dots now uses the color `#E0F2FE` (similar to Tailwind's `sky-100`). This replaces the previous gray color.

This change aims to make the background pattern more visually appealing while maintaining its subtlety.