### PR TITLE
feat: Implement real-time online user count display

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -7,7 +7,7 @@ import google.generativeai as genai
 import json
 from dotenv import load_dotenv # <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< IMPORT THIS
 import firebase_admin
-from firebase_admin import credentials, auth
+from firebase_admin import credentials, auth, db
 from typing import Optional # Added for Optional email in FirebaseUser
 
 # --- .env DEBUG START ---
@@ -269,6 +269,28 @@ async def get_user_details(user_id: str):
         "tasks_completed": ["Exercise 1", "Exercise 2"]
     }
     return UserDetails(**mock_user_data)
+
+
+@app.get("/api/online-users")
+async def get_online_users():
+    try:
+        ref = db.reference("/status")
+        status_data = ref.get()
+
+        if status_data is None or not isinstance(status_data, dict):
+            count = 0
+        else:
+            count = 0
+            for user_status in status_data.values(): # Iterate through the values (dictionaries for each user)
+                if isinstance(user_status, dict) and user_status.get("online") is True:
+                    count += 1
+
+        return {"online_users": count}
+    except Exception as e:
+        # Log the error for debugging
+        print(f"Error accessing Firebase Realtime Database: {e}")
+        # Return a generic error message to the client
+        raise HTTPException(status_code=500, detail="Failed to retrieve online user count from the database.")
 
 # Comments for running the app
 # To run this application:

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { StudentProgress } from '../types'; // Ensure this path is correct
-import { User, Trophy, Target, Clock, HelpCircle } from 'lucide-react'; // Added HelpCircle
+import { User, Trophy, Target, Clock, HelpCircle, Signal } from 'lucide-react'; // Added HelpCircle & Signal
 import { useAuth } from '../contexts/AuthContext';
+import { getDatabase, ref, onValue, off } from 'firebase/database';
+import { app } from '../../firebaseConfig'; // Firebase app instance
 
 interface HeaderProps {
   progress: StudentProgress;
@@ -10,6 +12,30 @@ interface HeaderProps {
 
 export const Header: React.FC<HeaderProps> = ({ progress, onOpenGuide }) => {
   const { currentUser, signInWithGoogle, signOut, loading } = useAuth();
+  const [onlineUsersCount, setOnlineUsersCount] = useState(0);
+
+  useEffect(() => {
+    if (!currentUser) {
+      setOnlineUsersCount(0); // Reset count if user logs out
+      return;
+    }
+
+    const db = getDatabase(app);
+    const statusRef = ref(db, '/status');
+
+    const listener = onValue(statusRef, (snapshot) => {
+      const statuses = snapshot.val();
+      let count = 0;
+      if (statuses) {
+        count = Object.values(statuses).filter(status => (status as any)?.online === true).length;
+      }
+      setOnlineUsersCount(count);
+    });
+
+    return () => {
+      off(statusRef, 'value', listener); // Detach the listener by providing all args
+    };
+  }, [currentUser]); // Re-run if currentUser changes (login/logout)
 
   return (
     <header className="bg-white border-b border-gray-200 px-4 sm:px-6 py-3"> {/* Adjusted padding for smaller screens */}
@@ -31,9 +57,15 @@ export const Header: React.FC<HeaderProps> = ({ progress, onOpenGuide }) => {
 
         {/* Right Section: Stats, Auth, and Guide Button */}
         <div className="flex items-center space-x-3 sm:space-x-4 md:space-x-6">
-          {/* Stats - Conditionally render based on user and screen size */}
+          {/* Stats & Online Users Count - Conditionally render based on user and screen size */}
           {currentUser && (
             <div className="hidden lg:flex items-center space-x-3 md:space-x-4"> {/* Hidden on smaller than lg */}
+              <div className="flex items-center text-green-600" title="Online Users">
+                <Signal size={16} className="mr-1" />
+                <span className="text-xs sm:text-sm font-medium">
+                  {onlineUsersCount} Online
+                </span>
+              </div>
               <div className="flex items-center" title="Total Score">
                 <Trophy className="w-4 h-4 text-yellow-500 mr-1" />
                 <span className="text-xs sm:text-sm font-medium text-gray-700">
@@ -57,6 +89,16 @@ export const Header: React.FC<HeaderProps> = ({ progress, onOpenGuide }) => {
                   {new Date(progress.lastAccessedAt).toLocaleDateString()}
                 </span>
               </div>
+            </div>
+          )}
+
+          {/* Mobile Online Users Count (visible on smaller than lg) */}
+          {currentUser && (
+            <div className="flex items-center text-green-600 lg:hidden" title="Online Users">
+              <Signal size={16} className="mr-1" />
+              <span className="text-xs sm:text-sm font-medium">
+                {onlineUsersCount}
+              </span>
             </div>
           )}
 

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -2,7 +2,8 @@
 import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
 import toast from 'react-hot-toast';
 import { User as FirebaseUser, onAuthStateChanged, signOut as firebaseSignOut, GoogleAuthProvider, signInWithPopup } from 'firebase/auth';
-import { auth } from '../firebaseConfig'; // Your Firebase auth instance
+import { auth, app } from '../firebaseConfig'; // Your Firebase auth instance and app instance
+import { getDatabase, ref, set, onDisconnect, serverTimestamp, onValue, Unsubscribe } from 'firebase/database'; // Firebase Realtime Database
 
 // Define the shape of the user object you want to store (can be extended)
 interface AppUser {
@@ -85,30 +86,89 @@ export const AuthProvider: React.FC<{children: ReactNode}> = ({ children }) => {
 
   const signOut = async () => {
     try {
+      if (currentUser) {
+        const db = getDatabase(app);
+        const userStatusDatabaseRef = ref(db, '/status/' + currentUser.uid);
+        await set(userStatusDatabaseRef, { online: false, last_changed: serverTimestamp() });
+      }
       await firebaseSignOut(auth);
       setCurrentUser(null);
       // setBackendUser(null);
     } catch (error) {
       console.error("Error signing out:", error);
+      toast.error("Error signing out.");
     }
   };
 
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, async (firebaseUser: FirebaseUser | null) => {
+    let presenceOnValueUnsubscribe: Unsubscribe | undefined;
+    let userStatusDatabaseRefClean: any = null; // To store ref for onDisconnect cleanup
+
+    const authUnsubscribe = onAuthStateChanged(auth, async (firebaseUser: FirebaseUser | null) => {
       if (firebaseUser) {
-        // When auth state changes (e.g. page reload),
-        // we have the Firebase user. If we had a separate backend session or user profile,
-        // we might want to re-fetch/validate it here.
-        // For this example, direct mapping is fine.
         setCurrentUser(mapFirebaseUserToAppUser(firebaseUser));
+
+        const db = getDatabase(app);
+        const userStatusDatabaseRef = ref(db, '/status/' + firebaseUser.uid);
+        userStatusDatabaseRefClean = userStatusDatabaseRef; // Save for potential cleanup
+        const presenceRef = ref(db, '.info/connected');
+
+        // Clean up previous listener if any
+        if (presenceOnValueUnsubscribe) {
+          presenceOnValueUnsubscribe();
+        }
+
+        presenceOnValueUnsubscribe = onValue(presenceRef, (snapshot) => {
+          if (snapshot.val() === false) {
+            // If disconnected, Firebase Realtime Database handles setting offline via onDisconnect
+            // No immediate action needed here unless explicitly required by logic
+            return;
+          }
+          // User is connected (or reconnected)
+          onDisconnect(userStatusDatabaseRef).set({ online: false, last_changed: serverTimestamp() })
+            .then(() => {
+              set(userStatusDatabaseRef, { online: true, last_changed: serverTimestamp() });
+            })
+            .catch((error) => {
+              console.error("Error setting up onDisconnect or user status:", error);
+            });
+        });
+
       } else {
+        // User is logged out
+        if (presenceOnValueUnsubscribe) {
+          presenceOnValueUnsubscribe(); // Detach the .info/connected listener
+          presenceOnValueUnsubscribe = undefined;
+        }
+        // If there was an active onDisconnect setup for a user,
+        // and they logged out manually, it should ideally be cancelled.
+        // However, onDisconnect is designed to fire when the client *actually* disconnects.
+        // If the user logged out gracefully, we already set their status to offline in `signOut`.
+        // If `userStatusDatabaseRefClean` is available, we can try to cancel:
+        if (userStatusDatabaseRefClean) {
+            // onDisconnect(userStatusDatabaseRefClean).cancel(); // Not strictly necessary if signOut handles it
+            // We can also just remove the status node or set to offline if not handled by signOut,
+            // but signOut *is* handling it.
+        }
         setCurrentUser(null);
       }
       setLoading(false);
     });
 
-    return () => unsubscribe(); // Cleanup subscription on unmount
-  }, []);
+    return () => {
+      authUnsubscribe(); // Cleanup Firebase Auth subscription
+      if (presenceOnValueUnsubscribe) {
+        presenceOnValueUnsubscribe(); // Cleanup presence listener
+      }
+      // If there's an onDisconnect set for a user and the component unmounts (e.g. app closing, not just logout)
+      // it should ideally be cancelled. However, onDisconnect is tied to the connection itself.
+      // If userStatusDatabaseRefClean is available:
+      // if (userStatusDatabaseRefClean) {
+      //   onDisconnect(userStatusDatabaseRefClean).cancel();
+      // }
+      // Forcing offline on component unmount might be too aggressive if it's not a true disconnect/logout
+    };
+  }, []); // currentUser removed from dependency array to avoid re-running on its change
 
   return (
     <AuthContext.Provider value={{ currentUser, loading, signInWithGoogle, signOut }}>


### PR DESCRIPTION
This feature introduces a real-time display of the number of currently online users.

Key changes:

Backend (`backend/main.py`):
- Added a new API endpoint `/api/online-users`.
- This endpoint queries Firebase Realtime Database (`/status` path) to count users with `online: true`.
- Fixed an initial bug where it counted all users under `/status` instead of only those marked as online.

Frontend (`src/`):
- `contexts/AuthContext.tsx`:
    - Implemented user presence tracking using Firebase Realtime Database.
    - When you log in, your status is set to `{online: true, last_changed: serverTimestamp()}` at `/status/{uid}`.
    - `onDisconnect` handler ensures status is updated to `{online: false, ...}` if you disconnect abruptly.
    - On explicit logout, status is immediately set to `{online: false, ...}`.
- `components/Header.tsx`:
    - Displays the online user count fetched in real-time from the `/status` path in Firebase Realtime Database.
    - Shows a green icon (Signal) and the count (e.g., "186 Online").
    - The display is responsive, showing a compact version on smaller screens.
    - The count is only displayed for logged-in users.

Testing:
- Backend API was tested to ensure correct counting of online users.
- Frontend logic was reviewed for correct presence management and display updates.