### PR TITLE
Fix: Restore chat window toggle functionality

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -758,10 +758,16 @@ function App() {
                       onClose={() => setIsChatOpen(false)}
                       onFlowchartGenerated={handleNewFlowchartFromAI}
                    />}
+
+      {/* Chat Toggle Button */}
+      <button
+        onClick={() => setIsChatOpen(!isChatOpen)}
         title={isChatOpen ? "Close AI Chat" : "Open AI Chat"}
         aria-label={isChatOpen ? "Close AI Chat" : "Open AI Chat"}
-      
+        className="fixed bottom-4 right-4 bg-blue-600 hover:bg-blue-700 text-white p-3 rounded-full shadow-lg z-50"
+      >
         {isChatOpen ? <X size={24} /> : <Bot size={24} />}
+      </button>
 
       {showDryRunInputModal && currentFlowchart && (
         <DryRunInputModal


### PR DESCRIPTION
The button to open and close the chat window was not rendering correctly due to malformed JSX in App.tsx.

This commit wraps the chat toggle icon and related props within a proper button element and ensures its onClick handler correctly toggles the chat window's visibility.