### PR TITLE
feat: Implement NavGurukul-only domain restriction for login

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,74 @@
 # Flowchart-to-Code-learning
 
 [Edit in StackBlitz next generation editor ⚡️](https://stackblitz.com/~/github.com/surajsahani/Flowchart-to-Code-learning)
+
+## Security and Domain Restriction
+
+This application is configured to restrict access to users with `@navgurukul.org` email addresses. This is enforced on both the client-side and server-side.
+
+### Client-Side Enforcement
+
+*   When a user attempts to sign in with Google, the application checks their email domain after successful authentication with Google.
+*   If the email domain is not `@navgurukul.org`, the user is immediately signed out from Firebase, and a modal is displayed informing them of the domain restriction.
+*   This logic resides in `src/contexts/AuthContext.tsx`.
+
+### Server-Side Enforcement
+
+*   The backend API (FastAPI application in `backend/main.py`) also enforces this domain restriction.
+*   The `/auth/google` endpoint, used to finalize user authentication with the backend, verifies the Firebase ID token and checks the email domain. Non-`@navgurukul.org` users will receive a 403 Forbidden error.
+*   Protected endpoints (e.g., `/api/chat`, `/users/{user_id}/details`) require a valid Firebase ID token from a `@navgurukul.org` user. A reusable dependency (`get_current_user_data`) handles this verification.
+    *   Requests to these endpoints without a valid token or from a non-allowed domain will result in 401 Unauthorized or 403 Forbidden errors.
+    *   The `/users/{user_id}/details` endpoint further ensures that the authenticated user can only access their own data.
+
+### Firestore Security Rules
+
+To ensure data in Firestore is also protected and accessible only by authenticated NavGurukul users, you **must** update your Firestore security rules in the Firebase console.
+
+It is recommended to implement rules similar to the following:
+
+```firestore
+rules_version = '2';
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+    // Example: User progress data
+    // Assumes user progress is stored under a collection 'userProgress'
+    // where document IDs are user UIDs.
+    match /userProgress/{userId} {
+      // Allow read and write only if the requesting user is authenticated,
+      // their email is verified, their email ends with '@navgurukul.org',
+      // and they are accessing their own document.
+      allow read, write: if request.auth != null &&
+                            request.auth.token.email_verified == true &&
+                            request.auth.token.email.endsWith('@navgurukul.org') &&
+                            request.auth.uid == userId;
+    }
+
+    // Example: Other collections that need protection
+    // match /someOtherCollection/{docId} {
+    //   allow read, write: if request.auth != null &&
+    //                         request.auth.token.email_verified == true &&
+    //                         request.auth.token.email.endsWith('@navgurukul.org');
+    //   // Adjust read/write permissions as needed for specific collections.
+    //   // Some collections might only need read access for all NavGurukul users,
+    //   // while others might be more restrictive.
+    // }
+
+    // Ensure to add rules for all collections you use.
+    // By default, if no rule matches, access is denied.
+  }
+}
+```
+
+**Important:**
+*   Test these rules thoroughly in the Firebase console's rules playground before applying them to your production environment.
+*   Adapt the collection paths (e.g., `userProgress/{userId}`) to match your actual Firestore database structure.
+*   The `request.auth.token.email_verified == true` check is a good practice to ensure the email address is legitimate.
+
+### Adjusting the Allowed Domain
+
+Currently, the allowed domain is hardcoded as `@navgurukul.org` in:
+*   `src/contexts/AuthContext.tsx` (client-side)
+*   `backend/main.py` (server-side)
+
+If you need to change or add allowed domains, you would need to update the `ALLOWED_DOMAIN` constant in these files. For more complex scenarios (e.g., multiple allowed domains from a configuration), the implementation would need to be adjusted accordingly.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,7 @@
-from datetime import datetime  # Added import
+from datetime import datetime, timezone # Added import
 from typing import List  # Added import
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import FastAPI, HTTPException, Request, Depends
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from fastapi.middleware.cors import CORSMiddleware  # Ensure this is imported
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
@@ -188,6 +189,48 @@ class FirebaseUser(BaseModel):
     email: Optional[str] = None
 
 
+class AuthenticatedUser(BaseModel):
+    uid: str
+    email: str
+
+# Security scheme for Bearer token
+oauth2_scheme = HTTPBearer()
+ALLOWED_DOMAIN = "navgurukul.org"
+
+async def get_current_user_data(credentials: HTTPAuthorizationCredentials = Depends(oauth2_scheme)) -> AuthenticatedUser:
+    token = credentials.credentials
+    if not token:
+        raise HTTPException(
+            status_code=401,
+            detail="Not authenticated",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    try:
+        decoded_token = auth.verify_id_token(token)
+        uid = decoded_token.get("uid")
+        email = decoded_token.get("email")
+        if not email or not uid:
+            raise HTTPException(status_code=401, detail="UID or Email not found in token.")
+        if not email.endswith(f"@{ALLOWED_DOMAIN}"):
+            raise HTTPException(status_code=403, detail=f"Access restricted to {ALLOWED_DOMAIN} domain.")
+        return AuthenticatedUser(uid=uid, email=email)
+    except firebase_admin.auth.InvalidIdTokenError:
+        raise HTTPException(
+            status_code=401,
+            detail="Invalid authentication credentials",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    except HTTPException as http_exc:
+        raise http_exc # Re-raise HTTPException explicitly
+    except Exception as e:
+        # Log the exception for server-side review
+        print(f"Error during token verification or domain check: {e}")
+        raise HTTPException(
+            status_code=500, # Keep this for genuinely unexpected errors
+            detail="Could not verify authentication credentials."
+        )
+
+
 @app.get("/")
 async def read_root():
     status = "Gemini Configured and Model Initialized" if model else "Gemini NOT Configured or Model Init Failed - Check Logs & .env setup"
@@ -195,8 +238,8 @@ async def read_root():
 
 
 @app.post("/api/chat")
-async def handle_chat_message(chat_message: ChatMessage):
-
+async def handle_chat_message(chat_message: ChatMessage, current_user: AuthenticatedUser = Depends(get_current_user_data)):
+    print(f"User {current_user.email} (UID: {current_user.uid}) accessing chat.")
     user_message = chat_message.message.strip()
     response_text = ""
     is_structured_data = False
@@ -345,17 +388,35 @@ async def auth_google_signin(id_token_body: IdToken):
         decoded_token = auth.verify_id_token(token_string)
         uid = decoded_token['uid']
         email = decoded_token.get('email')
+
+        if not email:
+            raise HTTPException(status_code=400, detail="Email not found in token.")
+
+        if not email.endswith('@navgurukul.org'):
+            raise HTTPException(status_code=403, detail="Access restricted to navgurukul.org domain.")
+
         # Here you would typically create or update the user in your database
         return FirebaseUser(uid=uid, email=email)
     except firebase_admin.auth.InvalidIdTokenError as e:
         raise HTTPException(status_code=401, detail=f"Invalid ID token: {e}")
+    except HTTPException as http_exc: # Re-raise HTTPException
+        raise http_exc
     except Exception as e:  # Catch other potential errors during token verification
         raise HTTPException(
             status_code=401, detail=f"Token verification failed: {e}")
 
 
 @app.get("/users/{user_id}/details", response_model=UserDetails)
-async def get_user_details(user_id: str):
+async def get_user_details(user_id: str, current_user: AuthenticatedUser = Depends(get_current_user_data)):
+    # Now current_user.uid contains the UID of the authenticated user.
+    # And current_user.email contains their email.
+    # The domain check is already handled by get_current_user_data.
+
+    if current_user.uid != user_id:
+        raise HTTPException(status_code=403, detail="Not authorized to access this user's details.")
+
+    print(f"User {current_user.email} (UID: {current_user.uid}) requesting details for {user_id}.")
+
     try:
         # Ensure Firebase Admin SDK is initialized
         if not firebase_admin._apps:
@@ -384,7 +445,7 @@ async def get_user_details(user_id: str):
             tasks_completed_str = [str(ex_id) for ex_id in progress_data.get("completedExercises", [])]
 
             # Ensure last_active is a datetime object
-            last_active_iso = progress_data.get("lastAccessedAt", datetime.utcnow().isoformat())
+            last_active_iso = progress_data.get("lastAccessedAt", datetime.now(timezone.utc).isoformat())
             try:
                 last_active_dt = datetime.fromisoformat(last_active_iso.replace("Z", "+00:00"))
             except ValueError: # Handle cases where it might not be full ISO format

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -1,5 +1,5 @@
 from fastapi.testclient import TestClient
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock, AsyncMock
 import firebase_admin # Import the base module to mock auth
 from firebase_admin import auth # Specifically for InvalidIdTokenError if needed directly
 
@@ -26,16 +26,18 @@ client = TestClient(app)
 # auth module itself isn't available due to a failed initial firebase_admin.initialize_app().
 # A more robust setup might involve a conftest.py to initialize Firebase for the test suite.
 
-@patch('firebase_admin.auth.verify_id_token')
-def test_auth_google_success(mock_verify_id_token):
-    # Configure the mock to return a dictionary representing a decoded token
-    mock_verify_id_token.return_value = {'uid': 'testuid123', 'email': 'test@example.com'}
-
-    response = client.post("/auth/google", json={"token": "dummy_token_string"})
-
-    assert response.status_code == 200
-    assert response.json() == {"uid": "testuid123", "email": "test@example.com"}
-    mock_verify_id_token.assert_called_once_with("dummy_token_string")
+# This test is removed because its success case (non-NG domain) is now a failure (403).
+# The case is covered by test_auth_google_failure_other_domain.
+# @patch('firebase_admin.auth.verify_id_token')
+# def test_auth_google_success(mock_verify_id_token):
+#     # Configure the mock to return a dictionary representing a decoded token
+#     mock_verify_id_token.return_value = {'uid': 'testuid123', 'email': 'test@example.com'}
+#
+#     response = client.post("/auth/google", json={"token": "dummy_token_string"})
+#
+#     assert response.status_code == 200 # This would now be 403
+#     assert response.json() == {"uid": "testuid123", "email": "test@example.com"}
+#     mock_verify_id_token.assert_called_once_with("dummy_token_string")
 
 @patch('firebase_admin.auth.verify_id_token')
 def test_auth_google_invalid_token(mock_verify_id_token):
@@ -55,6 +57,30 @@ def test_auth_google_invalid_token(mock_verify_id_token):
     assert "Invalid ID token" in response.json()["detail"]
     mock_verify_id_token.assert_called_once_with("invalid_dummy_token")
 
+@patch('firebase_admin.auth.verify_id_token')
+def test_auth_google_success_navgurukul_domain(mock_verify_id_token):
+    mock_verify_id_token.return_value = {'uid': 'nguser123', 'email': 'student@navgurukul.org'}
+    response = client.post("/auth/google", json={"token": "ng_token_string"})
+    assert response.status_code == 200
+    assert response.json() == {"uid": "nguser123", "email": "student@navgurukul.org"}
+    mock_verify_id_token.assert_called_once_with("ng_token_string")
+
+@patch('firebase_admin.auth.verify_id_token')
+def test_auth_google_failure_other_domain(mock_verify_id_token):
+    mock_verify_id_token.return_value = {'uid': 'otheruser123', 'email': 'test@example.com'}
+    response = client.post("/auth/google", json={"token": "other_domain_token"})
+    assert response.status_code == 403
+    assert response.json() == {"detail": "Access restricted to navgurukul.org domain."}
+    mock_verify_id_token.assert_called_once_with("other_domain_token")
+
+@patch('firebase_admin.auth.verify_id_token')
+def test_auth_google_failure_no_email_in_token(mock_verify_id_token):
+    mock_verify_id_token.return_value = {'uid': 'userwithnoemail'} # No email key
+    response = client.post("/auth/google", json={"token": "no_email_token"})
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Email not found in token."}
+    mock_verify_id_token.assert_called_once_with("no_email_token")
+
 def test_auth_google_missing_token():
     response = client.post("/auth/google", json={}) # Empty JSON body
     assert response.status_code == 422 # Unprocessable Entity for Pydantic validation error
@@ -62,13 +88,145 @@ def test_auth_google_missing_token():
     response_no_token_field = client.post("/auth/google", json={"not_token": "some_value"})
     assert response_no_token_field.status_code == 422
 
-# Test for the /users/{user_id}/details endpoint (remains unchanged but kept for completeness)
-def test_get_user_details():
-    response = client.get("/users/testuser/details")
+# --- Tests for /users/{user_id}/details endpoint ---
+
+@patch('firebase_admin.initialize_app') # Mock Firebase app initialization
+@patch.object(firebase_admin, '_apps', ['mock_app']) # Ensure _apps is not empty
+@patch('firebase_admin.auth.verify_id_token')
+@patch('firebase_admin.db.reference') # Mocking Firebase DB call
+def test_get_user_details_success(mock_db_ref, mock_verify_id_token, mock_initialize_app): # mock_apps_true removed
+    # Mock for verify_id_token
+    user_uid = "testuser123"
+    user_email = "testuser@navgurukul.org"
+    mock_verify_id_token.return_value = {'uid': user_uid, 'email': user_email}
+
+    # Mock for Firebase Realtime DB
+    mock_user_progress_data = {
+        "completedExercises": [1, 2],
+        "totalScore": 150,
+        "lastAccessedAt": "2023-01-01T12:00:00Z"
+    }
+    # Configure the chain of mocks for db.reference().get()
+    mock_ref_instance = mock_db_ref.return_value
+    mock_ref_instance.get.return_value = mock_user_progress_data
+
+    response = client.get(
+        f"/users/{user_uid}/details",
+        headers={"Authorization": "Bearer dummyfbtoken"}
+    )
+
     assert response.status_code == 200
     data = response.json()
-    assert "last_active" in data
-    assert "points" in data
-    assert "tasks_completed" in data
-    assert isinstance(data["points"], int)
-    assert data["points"] == 100
+    assert "last_active" in data # This comes from lastAccessedAt
+    assert data["points"] == mock_user_progress_data["totalScore"]
+    assert data["tasks_completed"] == [str(ex_id) for ex_id in mock_user_progress_data["completedExercises"]]
+    mock_verify_id_token.assert_called_once_with("dummyfbtoken")
+    mock_db_ref.assert_called_once_with(f'userProgress/{user_uid}')
+    mock_ref_instance.get.assert_called_once()
+
+
+@patch('firebase_admin.auth.verify_id_token')
+def test_get_user_details_unauthorized_different_user(mock_verify_id_token):
+    requesting_user_uid = "requesteruid"
+    target_user_uid = "otheruseruid"
+    mock_verify_id_token.return_value = {'uid': requesting_user_uid, 'email': 'requester@navgurukul.org'}
+
+    response = client.get(
+        f"/users/{target_user_uid}/details",
+        headers={"Authorization": "Bearer sometoken"}
+    )
+    assert response.status_code == 403
+    assert response.json() == {"detail": "Not authorized to access this user's details."}
+    mock_verify_id_token.assert_called_once_with("sometoken")
+
+
+@patch('firebase_admin.auth.verify_id_token')
+def test_get_user_details_forbidden_other_domain(mock_verify_id_token):
+    user_uid = "testuser123"
+    mock_verify_id_token.return_value = {'uid': user_uid, 'email': 'testuser@example.com'} # Non-NG domain
+
+    response = client.get(
+        f"/users/{user_uid}/details",
+        headers={"Authorization": "Bearer otherdomaintoken"}
+    )
+    assert response.status_code == 403
+    assert response.json() == {"detail": f"Access restricted to navgurukul.org domain."}
+    mock_verify_id_token.assert_called_once_with("otherdomaintoken")
+
+
+def test_get_user_details_no_token():
+    response = client.get("/users/anyuser/details") # No Authorization header
+    assert response.status_code == 403 # FastAPI's HTTPBearer returns 403 if not found, not 401
+    assert response.json() == {"detail": "Not authenticated"}
+
+
+# --- Tests for /api/chat endpoint ---
+
+import pytest # Required for @pytest.mark.asyncio
+
+@patch('main.configure_gemini') # Patch configure_gemini in main.py
+@patch('firebase_admin.auth.verify_id_token')
+@pytest.mark.asyncio
+async def test_chat_endpoint_success(mock_verify_id_token, mock_configure_gemini):
+    user_uid = "chatuser123"
+    user_email = "chatuser@navgurukul.org"
+    mock_verify_id_token.return_value = {'uid': user_uid, 'email': user_email}
+
+    # Mock the Gemini model and its response
+    mock_gemini_model = mock_configure_gemini.return_value
+    if mock_gemini_model is None: # If configure_gemini returns None
+        mock_gemini_model = mock_configure_gemini.return_value = MagicMock() # Ensure it's a mock
+
+    # Mock the async method generate_content_async
+    mock_ai_response = MagicMock()
+    mock_ai_response.text = "Hello from AI!"
+
+    # If generate_content_async is an async generator or needs await:
+    mock_gemini_model.generate_content_async = AsyncMock(return_value=mock_ai_response)
+    # For a simple return, plain MagicMock with a coroutine works for awaited calls
+    # async def async_generate_content(*args, **kwargs):
+    #     return mock_ai_response
+    # mock_gemini_model.generate_content_async = async_generate_content
+
+
+    chat_topic = "loops"
+    test_message = f"/learn {chat_topic}"
+    expected_prompt = (
+        f"Explain the programming concept of '{chat_topic}' clearly and concisely, as if to a beginner learning about flowcharts.\n"
+        f"Your explanation should include:\n"
+        f"1. A definition of the concept.\n"
+        f"2. How it is typically represented in a flowchart (mention symbol types if specific).\n"
+        f"3. A very simple pseudo-code or code example (e.g., Python or JavaScript) to illustrate its use.\n"
+        f"4. One or two key takeaways or common pitfalls related to '{chat_topic}'.\n"
+        f"Focus on educational value and clarity. Use markdown for formatting if it helps readability (e.g., for lists or code blocks)."
+    )
+
+    response = client.post(
+        "/api/chat",
+        headers={"Authorization": "Bearer validtoken"},
+        json={"message": test_message}
+    )
+    assert response.status_code == 200
+    assert response.json() == {"response": "Hello from AI!", "isStructuredData": False}
+    mock_verify_id_token.assert_called_once_with("validtoken")
+    # Check if configure_gemini was called (it's called inside the endpoint)
+    mock_configure_gemini.assert_called()
+    mock_gemini_model.generate_content_async.assert_called_once_with(expected_prompt)
+
+
+@patch('firebase_admin.auth.verify_id_token')
+def test_chat_endpoint_forbidden_other_domain(mock_verify_id_token):
+    mock_verify_id_token.return_value = {'uid': 'otherdomainuser', 'email': 'chat@example.com'}
+    response = client.post(
+        "/api/chat",
+        headers={"Authorization": "Bearer otherdomaintok"},
+        json={"message": "Hi"}
+    )
+    assert response.status_code == 403
+    assert response.json() == {"detail": f"Access restricted to navgurukul.org domain."}
+
+
+def test_chat_endpoint_no_token():
+    response = client.post("/api/chat", json={"message": "Hi"})
+    assert response.status_code == 403 # HTTPBearer returns 403
+    assert response.json() == {"detail": "Not authenticated"}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { getDatabase, ref, get, set, update, serverTimestamp } from 'firebase/da
 import { app } from "./firebaseConfig";
 import { ChevronLeft, ChevronRight, PanelLeft, PanelRight, Bot, X, PlaySquare, StepForward, Square, Users } from 'lucide-react'; // Added Users icon
 import { useAuth } from './contexts/AuthContext';
+import DomainBlockModal from './components/DomainBlockModal'; // Import the modal
 import { Header } from './components/Header';
 import { OnlineUsersPanel } from './components/OnlineUsersPanel'; // Import the new panel
 import { GamifiedExerciseMap } from './components/GamifiedExerciseMap';
@@ -22,7 +23,7 @@ import { FlowchartSimulator } from './engine/dryRun/FlowchartSimulator';
 import { DryRunInputModal } from './components/dryRun/DryRunInputModal';
 
 function App() {
-  const { currentUser, loading: authLoading } = useAuth();
+  const { currentUser, loading: authLoading, showDomainBlockModal, closeDomainBlockModal } = useAuth();
 
   // --- Standard App State ---
   const defaultInitialProgress: StudentProgress = {
@@ -790,6 +791,7 @@ function App() {
         onPrev={handleGuidePrev}
         onClose={handleGuideClose}
       />
+      <DomainBlockModal isOpen={showDomainBlockModal} onClose={closeDomainBlockModal} />
     </div>
   );
 }

--- a/src/components/DomainBlockModal.tsx
+++ b/src/components/DomainBlockModal.tsx
@@ -1,0 +1,55 @@
+// src/components/DomainBlockModal.tsx
+import React from 'react';
+
+interface DomainBlockModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const DomainBlockModal: React.FC<DomainBlockModalProps> = ({ isOpen, onClose }) => {
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div style={{
+      position: 'fixed',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      backgroundColor: 'rgba(0, 0, 0, 0.5)',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      zIndex: 1000,
+    }}>
+      <div style={{
+        backgroundColor: 'white',
+        padding: '20px',
+        borderRadius: '8px',
+        boxShadow: '0 2px 10px rgba(0, 0, 0, 0.1)',
+        textAlign: 'center',
+      }}>
+        <h2>Access Restricted</h2>
+        <p>Tool available only for navgurukul.org domain.</p>
+        <button
+          onClick={onClose}
+          style={{
+            marginTop: '15px',
+            padding: '10px 20px',
+            backgroundColor: '#007bff',
+            color: 'white',
+            border: 'none',
+            borderRadius: '4px',
+            cursor: 'pointer',
+          }}
+        >
+          OK
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default DomainBlockModal;

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -4,6 +4,9 @@ import toast from 'react-hot-toast';
 import { User as FirebaseUser, onAuthStateChanged, signOut as firebaseSignOut, GoogleAuthProvider, signInWithPopup } from 'firebase/auth';
 import { auth, app } from '../firebaseConfig'; // Your Firebase auth instance and app instance
 import { getDatabase, ref, set, onDisconnect, serverTimestamp, onValue, Unsubscribe } from 'firebase/database'; // Firebase Realtime Database
+import DomainBlockModal from '../components/DomainBlockModal'; // Import the modal
+
+const ALLOWED_DOMAIN = 'navgurukul.org';
 
 // Define the shape of the user object you want to store (can be extended)
 interface AppUser {
@@ -22,6 +25,8 @@ interface AuthContextType {
   loading: boolean;
   signInWithGoogle: () => Promise<void>;
   signOut: () => Promise<void>;
+  showDomainBlockModal: boolean; // Added state for modal
+  closeDomainBlockModal: () => void; // Added function to close modal
   // backendUser?: BackendUserDetails | null; // For user details from your own backend
 }
 
@@ -30,6 +35,7 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined);
 export const AuthProvider: React.FC<{children: ReactNode}> = ({ children }) => {
   const [currentUser, setCurrentUser] = useState<AppUser | null>(null);
   const [loading, setLoading] = useState(true);
+  const [showDomainBlockModal, setShowDomainBlockModal] = useState(false); // State for modal visibility
   // const [backendUser, setBackendUser] = useState<BackendUserDetails | null>(null);
 
   const mapFirebaseUserToAppUser = (firebaseUser: FirebaseUser): AppUser => {
@@ -37,8 +43,12 @@ export const AuthProvider: React.FC<{children: ReactNode}> = ({ children }) => {
       uid: firebaseUser.uid,
       email: firebaseUser.email,
       displayName: firebaseUser.displayName,
-      photoURL: firebaseUser.photoURL, // Add this line
+      photoURL: firebaseUser.photoURL,
     };
+  };
+
+  const closeDomainBlockModal = () => {
+    setShowDomainBlockModal(false);
   };
 
   const signInWithGoogle = async () => {
@@ -46,12 +56,22 @@ export const AuthProvider: React.FC<{children: ReactNode}> = ({ children }) => {
     try {
       const result = await signInWithPopup(auth, provider);
       const firebaseUser = result.user;
-      if (firebaseUser) {
+
+      if (firebaseUser && firebaseUser.email) {
+        const emailDomain = firebaseUser.email.split('@')[1];
+        if (emailDomain !== ALLOWED_DOMAIN) {
+          toast.error(`Access restricted to ${ALLOWED_DOMAIN} domain.`);
+          setShowDomainBlockModal(true);
+          await firebaseSignOut(auth); // Sign out immediately
+          setCurrentUser(null);
+          return; // Stop further processing
+        }
+
+        // Domain is allowed, proceed with backend authentication
         const idToken = await firebaseUser.getIdToken();
-        // TODO: Adjust the fetch URL if your backend is on a different port/domain
-        // e.g., http://localhost:8000/api/auth/google
-        const apiBaseUrl = import.meta.env.VITE_API_BASE_URL || ''; // Fallback to empty for same-origin or proxy
-        const endpoint = `${apiBaseUrl}/api/auth/google`;
+        const apiBaseUrl = import.meta.env.VITE_API_BASE_URL || '';
+        const endpoint = `${apiBaseUrl}/auth/google`; // Updated to /auth/google as per plan
+
         const response = await fetch(endpoint, {
           method: 'POST',
           headers: {
@@ -63,33 +83,46 @@ export const AuthProvider: React.FC<{children: ReactNode}> = ({ children }) => {
         if (!response.ok) {
           const errorData = await response.json();
           console.error('Backend auth error:', errorData);
-          // Potentially sign out the user from Firebase if backend validation fails critically
+          toast.error(errorData.detail || 'Failed to authenticate with backend.');
           await firebaseSignOut(auth);
           setCurrentUser(null);
-          // setBackendUser(null);
-          throw new Error(errorData.detail || 'Failed to authenticate with backend.');
+          // Potentially show a generic error modal or message
+          if (errorData.detail && errorData.detail.includes("domain")) {
+            setShowDomainBlockModal(true); // Show domain block modal if backend indicates domain issue
+          }
+          return;
         }
 
         // const backendData = await response.json(); // This is your FirebaseUser model from backend
         // console.log("Backend response:", backendData);
-        // For now, AppUser is derived from FirebaseUser directly after backend confirmation
+
         setCurrentUser(mapFirebaseUserToAppUser(firebaseUser));
 
-        // The following block for syncing localStorage to Firebase has been removed
-        // as it could cause data loss by overwriting newer Firebase data with
-        // potentially stale localStorage data. App.tsx handles loading from and
-        // saving to Firebase as the primary source of truth for logged-in users.
-        // console.log('Local storage to Firebase sync step skipped to prevent data overwriting.');
-
-        // Construct welcome message
         const welcomeMessage = firebaseUser.displayName
-          ? `Welcome, ${firebaseUser.displayName.split(' ')[0]}!` // Use first name if display name exists
+          ? `Welcome, ${firebaseUser.displayName.split(' ')[0]}!`
           : 'Signed in successfully!';
         toast.success(welcomeMessage);
+      } else if (firebaseUser && !firebaseUser.email) {
+        // Handle case where email is not available from provider, though unlikely for Google
+        toast.error('Could not retrieve email from provider. Please try again.');
+        await firebaseSignOut(auth);
+        setCurrentUser(null);
+        return;
       }
-    } catch (error) {
+    } catch (error: any) {
       console.error("Error during Google sign-in:", error);
-      // Handle errors here, perhaps set an error state
+      if (error.code === 'auth/popup-closed-by-user') {
+        toast.error('Sign-in cancelled.');
+      } else if (error.message && error.message.includes("domain")) { // Check if error message from backend indicates domain issue
+        setShowDomainBlockModal(true);
+      } else {
+        toast.error('An error occurred during sign-in.');
+      }
+      // Ensure user is signed out from Firebase if any error occurs during the process
+      if (auth.currentUser) {
+        await firebaseSignOut(auth);
+      }
+      setCurrentUser(null);
     }
   };
 
@@ -115,6 +148,17 @@ export const AuthProvider: React.FC<{children: ReactNode}> = ({ children }) => {
 
     const authUnsubscribe = onAuthStateChanged(auth, async (firebaseUser: FirebaseUser | null) => {
       if (firebaseUser) {
+        // Initial check: if a user is already authenticated in Firebase, verify their domain.
+        // This handles cases like page refresh.
+        if (firebaseUser.email && firebaseUser.email.split('@')[1] !== ALLOWED_DOMAIN) {
+          toast.error(`Access restricted to ${ALLOWED_DOMAIN} domain.`);
+          setShowDomainBlockModal(true);
+          await firebaseSignOut(auth); // Sign out from Firebase
+          setCurrentUser(null); // Clear local user state
+          setLoading(false);
+          return; // Stop further processing for this user
+        }
+        // If domain is okay or email is not yet available (should be rare for Google Auth)
         setCurrentUser(mapFirebaseUserToAppUser(firebaseUser));
 
         const db = getDatabase(app);
@@ -129,11 +173,8 @@ export const AuthProvider: React.FC<{children: ReactNode}> = ({ children }) => {
 
         presenceOnValueUnsubscribe = onValue(presenceRef, (snapshot) => {
           if (snapshot.val() === false) {
-            // If disconnected, Firebase Realtime Database handles setting offline via onDisconnect
-            // No immediate action needed here unless explicitly required by logic
             return;
           }
-          // User is connected (or reconnected)
           onDisconnect(userStatusDatabaseRef).set({ online: false, last_changed: serverTimestamp() })
             .then(() => {
               set(userStatusDatabaseRef, { online: true, last_changed: serverTimestamp() });
@@ -144,20 +185,12 @@ export const AuthProvider: React.FC<{children: ReactNode}> = ({ children }) => {
         });
 
       } else {
-        // User is logged out
         if (presenceOnValueUnsubscribe) {
-          presenceOnValueUnsubscribe(); // Detach the .info/connected listener
+          presenceOnValueUnsubscribe();
           presenceOnValueUnsubscribe = undefined;
         }
-        // If there was an active onDisconnect setup for a user,
-        // and they logged out manually, it should ideally be cancelled.
-        // However, onDisconnect is designed to fire when the client *actually* disconnects.
-        // If the user logged out gracefully, we already set their status to offline in `signOut`.
-        // If `userStatusDatabaseRefClean` is available, we can try to cancel:
         if (userStatusDatabaseRefClean) {
-            // onDisconnect(userStatusDatabaseRefClean).cancel(); // Not strictly necessary if signOut handles it
-            // We can also just remove the status node or set to offline if not handled by signOut,
-            // but signOut *is* handling it.
+          // onDisconnect(userStatusDatabaseRefClean).cancel(); // Not strictly necessary
         }
         setCurrentUser(null);
       }
@@ -165,22 +198,15 @@ export const AuthProvider: React.FC<{children: ReactNode}> = ({ children }) => {
     });
 
     return () => {
-      authUnsubscribe(); // Cleanup Firebase Auth subscription
+      authUnsubscribe();
       if (presenceOnValueUnsubscribe) {
-        presenceOnValueUnsubscribe(); // Cleanup presence listener
+        presenceOnValueUnsubscribe();
       }
-      // If there's an onDisconnect set for a user and the component unmounts (e.g. app closing, not just logout)
-      // it should ideally be cancelled. However, onDisconnect is tied to the connection itself.
-      // If userStatusDatabaseRefClean is available:
-      // if (userStatusDatabaseRefClean) {
-      //   onDisconnect(userStatusDatabaseRefClean).cancel();
-      // }
-      // Forcing offline on component unmount might be too aggressive if it's not a true disconnect/logout
     };
-  }, []); // currentUser removed from dependency array to avoid re-running on its change
+  }, []);
 
   return (
-    <AuthContext.Provider value={{ currentUser, loading, signInWithGoogle, signOut }}>
+    <AuthContext.Provider value={{ currentUser, loading, signInWithGoogle, signOut, showDomainBlockModal, closeDomainBlockModal }}>
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
This commit introduces a security enhancement to restrict application access to users with `@navgurukul.org` email addresses.

Key changes include:

Client-Side (src/):
- Modified `AuthContext.tsx` to check the user's email domain upon Google Sign-In. If the domain is not `@navgurukul.org`, the user is signed out, and a `DomainBlockModal.tsx` is displayed.
- Integrated the modal into `App.tsx`.
- Updated client to use the `/auth/google` backend endpoint.

Backend (backend/):
- Enhanced the `/auth/google` endpoint in `main.py` to verify the ID token and enforce the `@navgurukul.org` domain, returning 403 for others.
- Created a reusable FastAPI dependency `get_current_user_data` for token verification, domain checking, and extracting user UID/email.
- Protected `/users/{user_id}/details` and `/api/chat` endpoints using this dependency. `/users/{user_id}/details` now also ensures users can only access their own data.
- Addressed a `DeprecationWarning` by updating `datetime.utcnow()` to `datetime.now(datetime.timezone.utc)`.

Testing (backend/):
- Added comprehensive unit tests in `test_main.py` for new authentication and authorization logic, ensuring all pass.
- Installed `pytest-asyncio` for async tests.

Documentation:
- Updated `README.md` with a "Security and Domain Restriction" section, detailing client-side, server-side enforcement, guidance on necessary Firestore security rules (including domain checks), and instructions for adjusting the allowed domain.