### PR TITLE
Fix: Resolve regression making properties panel inputs uneditable

### DIFF
--- a/src/components/FlowchartBuilder.tsx
+++ b/src/components/FlowchartBuilder.tsx
@@ -244,6 +244,13 @@ export const FlowchartBuilder: React.FC<FlowchartBuilderProps> = ({
     return () => window.removeEventListener('resize', debouncedResize);
   }, []);
 
+  // Effect to open properties panel when a node is selected
+  useEffect(() => {
+    if (selectedNodeForProperties) {
+      setIsPropertiesOpen(true);
+    }
+  }, [selectedNodeForProperties]);
+
 
   const handleDragStart = (nodeType: FlowchartNodeType) => {
     setDraggedNodeType(nodeType);
@@ -377,7 +384,6 @@ export const FlowchartBuilder: React.FC<FlowchartBuilderProps> = ({
     } else {
     // Not in connecting mode, so select the node for properties panel
     setSelectedNodeForProperties(nodeId);
-    setIsPropertiesOpen(true); // Ensure the properties panel is open
   }
 
   // Update Firebase with the clicked node ID


### PR DESCRIPTION
A previous fix to ensure the properties panel opens correctly inadvertently caused a regression where the input fields within the panel became uneditable. This was due to setting `selectedNodeForProperties` and `isPropertiesOpen` simultaneously in the `handleNodeClick` event handler, likely causing rendering issues that interfered with input focus or state updates.

This commit addresses the regression by:
1. Removing the direct call to `setIsPropertiesOpen(true)` from `handleNodeClick`.
2. Introducing a `useEffect` hook that listens for changes to `selectedNodeForProperties`. When a node is selected, this effect now handles setting `isPropertiesOpen` to `true`.

This separation of concerns ensures that the properties panel opens reliably upon node selection without conflicting with the input fields' interactivity. The input fields are now fully editable again.