### PR TITLE
fix: Use environment variable for API base URL in frontend

### DIFF
--- a/src/components/FlowchartBuilder.tsx
+++ b/src/components/FlowchartBuilder.tsx
@@ -470,8 +470,13 @@ const handleImageFileSelect = async (event: React.ChangeEvent<HTMLInputElement>)
   const formData = new FormData();
   formData.append('file', file);
 
+  const apiBaseUrl = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000';
+  const endpoint = `${apiBaseUrl}/api/import-image`;
+
+  console.log(`Attempting to upload image to: ${endpoint}`);
+
   try {
-    const response = await fetch('http://localhost:8000/api/import-image', {
+    const response = await fetch(endpoint, {
       method: 'POST',
       body: formData,
       // Headers like 'Content-Type': 'multipart/form-data' are usually set automatically by the browser with FormData


### PR DESCRIPTION
- Modified FlowchartBuilder.tsx to use `import.meta.env.VITE_API_BASE_URL` to construct the API endpoint URL.
- Defaults to 'http://localhost:8000' if the environment variable is not set.
- This resolves the issue where the frontend would always call localhost:8000, causing connection errors in production.

Requires VITE_API_BASE_URL to be set in Vercel production environment (e.g., to https://flowchart-to-code-learning-1.onrender.com) and in local .env.local (to http://localhost:8000).