### PR TITLE
fix: Add python-multipart to backend requirements

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,3 +9,4 @@ ultralytics>=8.0.0 # For YOLOv8
 opencv-python-headless>=4.0.0 # For image processing
 Pillow>=9.0.0 # For image manipulation
 easyocr>=1.7.0 # For OCR
+python-multipart>=0.0.5 # For FastAPI file uploads


### PR DESCRIPTION
FastAPI requires python-multipart for handling form data (file uploads). This was missing, causing the backend deployment to fail when trying to register the /api/import-image route.

Adding python-multipart to requirements.txt resolves this runtime error.