### PR TITLE
Fix: Route frontend API calls to Render backend

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -95,12 +95,16 @@ def configure_gemini(gemini_version: str = "2.0") -> Optional[genai.GenerativeMo
     try:
         gemini_api_key = os.environ.get("GEMINI_API_KEY")
         # This debug print is crucial
-        print(
-            f"DEBUG: Inside Gemini config try block, value of 'gemini_api_key' variable is: {{gemini_api_key[:5] + '...' if gemini_api_key else 'None'}}")
+        if gemini_api_key:
+            print(
+                f"DEBUG: GEMINI_API_KEY FOUND in environment. Value: '{gemini_api_key[:5]}...' (partially shown)")
+        else:
+            print(
+                "DEBUG: GEMINI_API_KEY NOT FOUND in os.environ during Gemini configuration.")
 
         if not gemini_api_key:
             raise KeyError(
-                "GEMINI_API_KEY not found in environment. Please ensure it is set in your system environment or in a 'backend/.env' file.")
+                "GEMINI_API_KEY not found in environment. Please ensure it is set in your system environment (e.g., Render service environment variables) or in a 'backend/.env' file for local development.")
 
         genai.configure(api_key=gemini_api_key)
         print("INFO: Gemini SDK configured with API key.")
@@ -496,11 +500,14 @@ async def handle_chat_message(chat_message: ChatMessage): # Removed current_user
                 print(f"DEBUG: topic '{topic[:100]}'")
 
                 # Ensure model is configured
+        print("DEBUG: Attempting to configure Gemini model for '/learn' command...")
                 model = configure_gemini(gemini_version="2.0")
                 if model is None:
+            print("ERROR: Gemini model is None after configuration attempt in '/learn'.")
                     raise HTTPException(
-                status_code=503, detail="AI Service not configured or model not available. Ensure GEMINI_API_KEY is set and valid, and a suitable model is available.")
+                status_code=503, detail="AI Service not configured or model not available. Critical: GEMINI_API_KEY might be missing or invalid in the deployment environment (e.g., Render settings). Also, check model availability for your key.")
 
+            print(f"DEBUG: Gemini model object before calling generate_content_async: {model}")
             ai_response = await model.generate_content_async(prompt)
             # Print first 100 chars for brevity
             print(f"DEBUG: AI response received: {ai_response.text[:100]}...")
@@ -564,12 +571,15 @@ async def handle_chat_message(chat_message: ChatMessage): # Removed current_user
                     response_schema=response_schema,
                     candidate_count=1
                 )
+                print("DEBUG: Attempting to configure Gemini model for '/generate' command...")
                 model = configure_gemini(gemini_version="2.5")
                 if model is None:
+                    print("ERROR: Gemini model is None after configuration attempt in '/generate'.")
                     raise HTTPException(
-                        status_code=503, detail="AI Service not configured or model not available. Ensure GEMINI_API_KEY is set and valid, and a suitable model is available."
+                        status_code=503, detail="AI Service not configured or model not available. Critical: GEMINI_API_KEY might be missing or invalid in the deployment environment (e.g., Render settings). Also, check model availability for your key."
                     )
 
+                print(f"DEBUG: Gemini model object before calling generate_content_async: {model}")
                 # Pass the generation config to generate_content_async
                 ai_response = await model.generate_content_async(prompt, generation_config=generation_config)
                 try:

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -20,19 +20,22 @@ interface BackendApiResponse { // This is what the actual backend /api/chat retu
 
 // Helper to get the API base URL
 const getApiBaseUrl = (): string => {
-  const apiUrl = import.meta.env.VITE_API_URL;
+  // Using VITE_API_BASE_URL as per the new requirement
+  const apiUrl = import.meta.env.VITE_API_BASE_URL;
   if (!apiUrl) {
-    console.error("VITE_API_URL is not defined. Falling back to relative path /api. This may not work in all environments.");
-    // Fallback for local development if .env is not set up, assuming backend is on same host/port under /api
-    // In production, VITE_API_URL should definitely be set.
-    return ""; // Use relative path for /api/chat
+    // Fallback for local development, pointing to the typical local backend port
+    console.warn("VITE_API_BASE_URL is not defined. Falling back to http://localhost:8000. Ensure your local backend is running there or set VITE_API_BASE_URL.");
+    return "http://localhost:8000"; // Default to local backend URL
   }
   return apiUrl;
 };
 
 export const postRealChatMessage = async (data: ApiChatRequest): Promise<BackendApiResponse> => {
   const baseUrl = getApiBaseUrl();
-  const targetUrl = `${baseUrl}/api/chat`; // Construct the target URL
+  // Ensure targetUrl does not result in double slashes if baseUrl is empty or just "/"
+  const targetPath = "/api/chat";
+  const targetUrl = baseUrl.endsWith('/') ? `${baseUrl.slice(0, -1)}${targetPath}` : `${baseUrl}${targetPath}`;
+
 
   // If backend returns { response: string, isStructuredData: boolean } directly,
   // then the transformation to ChatMessage structure happens here.


### PR DESCRIPTION
- Modified src/services/api.ts to use VITE_API_BASE_URL environment variable to determine the backend API endpoint.
- Updated fallback URL to http://localhost:8000 for local development.
- This ensures that API requests from the Vercel-hosted frontend are correctly routed to the backend service hosted on Render.