### PR TITLE
Feat: Make chat context-aware of the current exercise

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -179,6 +179,8 @@ def configure_gemini(gemini_version: str = "2.0") -> Optional[genai.GenerativeMo
 
 class ChatMessage(BaseModel):
     message: str
+    exercise_id: Optional[str] = None
+    exercise_title: Optional[str] = None
 
 
 class UserDetails(BaseModel):
@@ -487,8 +489,13 @@ async def handle_chat_message(chat_message: ChatMessage): # Removed current_user
             if not topic:
                 response_text = "Please specify a topic after /learn. For example: /learn loops"
             else:
+                context_prefix = ""
+                if chat_message.exercise_title:
+                    context_prefix = f"Within the context of the exercise titled '{chat_message.exercise_title}', "
+                    print(f"DEBUG: Received exercise context: ID='{chat_message.exercise_id}', Title='{chat_message.exercise_title}'")
+
                 prompt = (
-                    f"Explain the programming concept of '{topic}' clearly and concisely, as if to a beginner learning about flowcharts.\n"
+                    f"{context_prefix}Explain the programming concept of '{topic}' clearly and concisely, as if to a beginner learning about flowcharts.\n"
                     f"Your explanation should include:\n"
                     f"1. A definition of the concept.\n"
                     f"2. How it is typically represented in a flowchart (mention symbol types if specific).\n"
@@ -497,7 +504,7 @@ async def handle_chat_message(chat_message: ChatMessage): # Removed current_user
                     f"Focus on educational value and clarity. Use markdown for formatting if it helps readability (e.g., for lists or code blocks)."
                 )
                 # Print first 100 chars for brevity
-                print(f"DEBUG: topic '{topic[:100]}'")
+                print(f"DEBUG: topic '{topic[:100]}' with context prefix: '{context_prefix[:100]}'")
 
                 # Ensure model is configured
         print("DEBUG: Attempting to configure Gemini model for '/learn' command...")

--- a/src/components/ExerciseChat.tsx
+++ b/src/components/ExerciseChat.tsx
@@ -70,7 +70,10 @@ const ExerciseChat: React.FC = () => {
         // If exerciseContext is needed by the real API, postRealChatMessage and backend must be updated.
         const apiResponse = await postRealChatMessage({
           message: userMessage.text,
-          exerciseContext: storeExerciseContext, // This context is not used by postRealChatMessage's fetch body currently
+          exerciseContext: storeExerciseContext ? {
+            currentExerciseId: storeExerciseContext.exerciseId, // Map from store's structure
+            title: storeExerciseContext.title,
+          } : null,
         });
 
         if (currentExerciseId) {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -2,7 +2,10 @@ import { ChatMessage, ExerciseContext } from '../store/chatStore';
 
 interface ApiChatRequest {
   message: string;
-  exerciseContext: ExerciseContext | null;
+  exerciseContext: { // Be more specific about what's needed from ExerciseContext
+    currentExerciseId?: number | string | null; // Allow for flexible ID types
+    title?: string | null;
+  } | null;
 }
 
 interface ApiChatResponseData { // Renamed to avoid conflict if we use the same name for the function's return type
@@ -50,8 +53,11 @@ export const postRealChatMessage = async (data: ApiChatRequest): Promise<Backend
       'Content-Type': 'application/json',
       // Authorization header comment removed as /api/chat is now public
     },
-    body: JSON.stringify({ message: data.message }), // Backend expects { "message": "..." }
-                                                    // It does not expect exerciseContext in the body for /api/chat
+    body: JSON.stringify({
+      message: data.message,
+      exercise_id: data.exerciseContext?.currentExerciseId?.toString(), // Ensure it's a string for backend
+      exercise_title: data.exerciseContext?.title,
+    }),
   });
 
   if (!response.ok) {


### PR DESCRIPTION
- Modified backend to accept exercise_id and exercise_title in chat requests.
- Updated backend chat prompt to include exercise title for /learn commands, providing more relevant AI responses.
- Modified frontend to send current exercise ID and title to the backend.
- Ensured frontend components correctly pass exercise context data to the API service.