### PR TITLE
Feat: Load generated flowchart from chat into builder

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,7 +27,10 @@ function App() {
   const { currentUser, loading: authLoading, showDomainBlockModal, closeDomainBlockModal } = useAuth();
   const setExerciseContext = useChatStore((s) => s.setExerciseContext);
   const exerciseContext = useChatStore((s) => s.exerciseContext);
-  const lastResyncRequested = useChatStore((s) => s.lastResyncRequested); // <-- Add this line
+  const lastResyncRequested = useChatStore((s) => s.lastResyncRequested);
+  const generatedFlowchartDataFromChat = useChatStore((s) => s.generatedFlowchartData);
+  const setGeneratedFlowchartDataInChatStore = useChatStore((s) => s.setGeneratedFlowchartData);
+
 
   // --- Standard App State ---
   const defaultInitialProgress: StudentProgress = {
@@ -582,6 +585,20 @@ function App() {
       });
     }
   }, [currentExercise, generatedCode, executionResult, setExerciseContext, lastResyncRequested]);
+
+  // Effect to load flowchart data generated from chat
+  useEffect(() => {
+    if (generatedFlowchartDataFromChat) {
+      console.log("App.tsx: Detected new flowchart data from chat store:", generatedFlowchartDataFromChat);
+      setAiFlowchartToLoad(generatedFlowchartDataFromChat); // This will pass it as a prop to FlowchartBuilder
+      // Optionally, also update currentFlowchart directly if FlowchartBuilder doesn't fully manage it via prop change
+      // setCurrentFlowchart(generatedFlowchartDataFromChat);
+      // handleFlowchartChange(generatedFlowchartDataFromChat); // This also generates code, might be desired
+
+      setGeneratedFlowchartDataInChatStore(null); // Reset in store after processing
+    }
+  }, [generatedFlowchartDataFromChat, setAiFlowchartToLoad, setGeneratedFlowchartDataInChatStore, handleFlowchartChange]);
+
 
   // Debug log for current exercise state at render time
   console.log(

--- a/src/components/ExerciseChat.tsx
+++ b/src/components/ExerciseChat.tsx
@@ -12,6 +12,7 @@ const ExerciseChat: React.FC = () => {
     addMessage,
     loadHistory,
     requestResync,
+    setGeneratedFlowchartData, // Added for AI flowchart generation
   } = useChatStore();
   const storeExerciseContext = useChatStore((state) => state.exerciseContext);
 
@@ -77,7 +78,27 @@ const ExerciseChat: React.FC = () => {
         });
 
         if (currentExerciseId) {
-            addMessage(currentExerciseId, apiResponse.reply);
+          let messageToStore = apiResponse.reply;
+          if (messageToStore.isStructuredData && messageToStore.text) {
+            try {
+              const flowchartData = JSON.parse(messageToStore.text);
+              if (flowchartData.nodes && flowchartData.edges) {
+                setGeneratedFlowchartData(flowchartData); // Update store
+                // Optionally, change the text displayed in chat:
+                // messageToStore = {
+                //   ...messageToStore,
+                //   text: "Flowchart generated! It should appear in the builder.",
+                // };
+                // For now, we'll keep the original JSON text in chat for debugging,
+                // but also signal that it has been processed.
+                console.log("Flowchart data parsed and set to store from chat message.");
+              }
+            } catch (e) {
+              console.error("Failed to parse structured data from chat message:", e);
+              // Keep original message text if parsing fails
+            }
+          }
+          addMessage(currentExerciseId, messageToStore);
         }
       } catch (error) {
         console.error("Error sending message to API:", error);

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -76,7 +76,7 @@ export const postRealChatMessage = async (data: ApiChatRequest): Promise<Backend
     sender: 'assistant',
     text: responseData.response, // This is the raw string, could be plain text or stringified JSON
     timestamp: Date.now(),
-    // isStructuredData: responseData.isStructuredData, // Add this if ChatMessage type is extended
+    isStructuredData: responseData.isStructuredData, // Populate from backend response
   };
 
   return { reply: replyMessage };

--- a/src/store/chatStore.ts
+++ b/src/store/chatStore.ts
@@ -10,11 +10,14 @@ export interface ExerciseContext { // Exporting
   previousHints: number | null;
 }
 
+import { FlowchartData } from '../types'; // Import FlowchartData
+
 export interface ChatMessage { // Exporting
   id: string;
   sender: 'user' | 'assistant';
   text: string;
   timestamp: number;
+  isStructuredData?: boolean; // Added to indicate if 'text' is JSON for flowchart
 }
 
 interface ChatState {
@@ -22,10 +25,12 @@ interface ChatState {
   currentExerciseId: string | null;
   exerciseContext: ExerciseContext | null;
   chatHistory: Record<string, ChatMessage[]>; // ExerciseId -> Messages
+  generatedFlowchartData: FlowchartData | null; // For AI generated flowcharts
   toggleVisibility: () => void;
   setExerciseContext: (context: ExerciseContext) => void;
   addMessage: (exerciseId: string | null, message: ChatMessage) => void;
   loadHistory: (exerciseId: string | null) => ChatMessage[];
+  setGeneratedFlowchartData: (data: FlowchartData | null) => void; // Setter for AI flowchart
   lastResyncRequested: number | null;
   requestResync: () => void;
 }
@@ -37,9 +42,11 @@ const useChatStore = create<ChatState>()(
       currentExerciseId: null,
       exerciseContext: null,
       chatHistory: {},
+      generatedFlowchartData: null, // Initialize
       lastResyncRequested: null,
       toggleVisibility: () => set((state) => ({ isVisible: !state.isVisible })),
       requestResync: () => set({ lastResyncRequested: Date.now() }),
+      setGeneratedFlowchartData: (data) => set({ generatedFlowchartData: data }), // Implement setter
       setExerciseContext: (context) =>
         set((state) => {
           // When context changes, update currentExerciseId


### PR DESCRIPTION
- Updated chat store to include state for AI-generated flowchart data.
- Modified ExerciseChat.tsx to parse structured JSON responses from the /generate command and set this data in the chat store.
- Updated App.tsx to observe the chat store for new flowchart data.
- When new data is available, App.tsx passes it to FlowchartBuilder.tsx, causing the visual flowchart to update automatically.
- Ensured ChatMessage type and API service correctly handle the isStructuredData flag.