### PR TITLE
Fix: Restore /generate command, add cheat mode, and UX polish

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ function App() {
   const lastResyncRequested = useChatStore((s) => s.lastResyncRequested);
   const generatedFlowchartDataFromChat = useChatStore((s) => s.generatedFlowchartData);
   const setGeneratedFlowchartDataInChatStore = useChatStore((s) => s.setGeneratedFlowchartData);
+  const isGeneratingFlowchart = useChatStore((s) => s.isGeneratingFlowchart); // Get loading state
 
 
   // --- Standard App State ---
@@ -209,16 +210,30 @@ function App() {
       }
 
       // Update progress if correct and not already completed
+      const isCheatMode = useChatStore.getState().isCheatModeSource;
+      if (isCheatMode) {
+        useChatStore.getState().setIsCheatModeSource(false); // Reset flag
+        console.log("Cheat mode was active. Progress not awarded.");
+        // Toast notification for cheat mode will be handled in ExerciseChat.tsx or a global toast service
+      }
+
       if (result.isCorrect && currentExerciseId !== null && !progress.completedExercises.includes(currentExerciseId)) {
-        const points = currentExercise!.difficulty === 'beginner' ? 50 :
-                       currentExercise!.difficulty === 'intermediate' ? 75 : 100;
-        
-        setProgress(prev => ({
-          ...prev,
-          completedExercises: [...prev.completedExercises, currentExerciseId!],
-          totalScore: prev.totalScore + points,
-          lastAccessedAt: new Date().toISOString()
-        }));
+        if (!isCheatMode) {
+          const points = currentExercise!.difficulty === 'beginner' ? 50 :
+                         currentExercise!.difficulty === 'intermediate' ? 75 : 100;
+
+          setProgress(prev => ({
+            ...prev,
+            completedExercises: [...prev.completedExercises, currentExerciseId!],
+            totalScore: prev.totalScore + points,
+            lastAccessedAt: new Date().toISOString()
+          }));
+          console.log("Progress awarded for completing exercise.");
+        } else {
+          // If it was cheat mode, and the solution is correct,
+          // we still might want to acknowledge it, but not give points.
+          // For now, the console log above handles the notification.
+        }
       }
     } catch (error) {
       setExecutionResult({
@@ -718,6 +733,7 @@ function App() {
                 onRunCode={handleRunCode} // This is for actual code execution, not dry run steps
                 isRunning={isRunning && !isDryRunMode} // Actual run is only when not in dry run
                 newFlowchartToLoad={aiFlowchartToLoad}
+                isGeneratingFlowchart={isGeneratingFlowchart} // Pass loading state for spinner
                 highlightedNodeId={isDryRunMode ? currentDryRunState?.currentProcessedNodeId : null} // Highlight current dry run node
               />
               {isCodeEditorOpen && (

--- a/src/components/ExerciseChat.tsx
+++ b/src/components/ExerciseChat.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect, useRef } from 'react';
+import toast from 'react-hot-toast'; // Import toast
 import useChatStore from '../store/chatStore';
-import { postRealChatMessage } from '../services/api'; // UPDATED IMPORT
-import './ExerciseChat.css'; // Import the CSS file
+import { postRealChatMessage } from '../services/api';
+import './ExerciseChat.css';
 
 const ExerciseChat: React.FC = () => {
   const {
@@ -12,7 +13,8 @@ const ExerciseChat: React.FC = () => {
     addMessage,
     loadHistory,
     requestResync,
-    setGeneratedFlowchartData, // Added for AI flowchart generation
+    setGeneratedFlowchartData,
+    setIsGeneratingFlowchart, // Get the setter for loading state
   } = useChatStore();
   const storeExerciseContext = useChatStore((state) => state.exerciseContext);
 
@@ -65,61 +67,94 @@ const ExerciseChat: React.FC = () => {
       setInputValue('');
       setIsBotTyping(true);
 
-      let messageToSend = userMessage.text;
-      const isGenerateCommand = userMessage.text.toLowerCase().startsWith('/generate ');
+      let command: 'chat' | 'learn' | 'generate' = 'chat';
+      let messageContent = userMessage.text;
 
-      if (isGenerateCommand) {
-        messageToSend = userMessage.text.substring('/generate '.length).trim();
+      if (userMessage.text.toLowerCase().startsWith('/generate ')) {
+        command = 'generate';
+        messageContent = userMessage.text.substring('/generate '.length).trim();
+        setIsGeneratingFlowchart(true); // Start loading before API call
+      } else if (userMessage.text.toLowerCase().startsWith('/learn ')) {
+        command = 'learn';
+        messageContent = userMessage.text.substring('/learn '.length).trim();
       }
 
       try {
-        // Ensure the context being sent matches what postRealChatMessage expects.
-        // The message field will now be the extracted prompt if it's a /generate command.
         const apiResponse = await postRealChatMessage({
-          message: messageToSend, // Use the potentially modified message
+          message: messageContent,
+          command: command,
           exerciseContext: storeExerciseContext ? {
-            currentExerciseId: storeExerciseContext.exerciseId, // Map from store's structure
+            currentExerciseId: storeExerciseContext.exerciseId,
             title: storeExerciseContext.title,
           } : null,
-          // We could add an explicit flag for the backend if it helps differentiate /generate calls
-          // isGenerateFlowchartRequest: isGenerateCommand
         });
 
         if (currentExerciseId) {
-          let messageToStore = apiResponse.reply;
-          if (messageToStore.isStructuredData && messageToStore.text) {
+          const botReply = apiResponse.reply;
+          if (command === 'generate' && botReply.isStructuredData && botReply.text) {
             try {
-              const flowchartData = JSON.parse(messageToStore.text);
+              const flowchartData = JSON.parse(botReply.text);
               if (flowchartData.nodes && flowchartData.edges) {
-                setGeneratedFlowchartData(flowchartData); // Update store
-                // Optionally, change the text displayed in chat:
-                // messageToStore = {
-                //   ...messageToStore,
-                //   text: "Flowchart generated! It should appear in the builder.",
-                // };
-                // For now, we'll keep the original JSON text in chat for debugging,
-                // but also signal that it has been processed.
+                setGeneratedFlowchartData(flowchartData);
+                useChatStore.getState().setIsCheatModeSource(true); // Set cheat mode source
+                 addMessage(currentExerciseId, {
+                   id: Date.now().toString() + '-flowchart-generated',
+                   sender: 'assistant',
+                   text: "Flowchart generated. You can see it on the canvas.",
+                   timestamp: Date.now(),
+                 });
+                toast.success("Flowchart generated in cheat mode – progress not counted.");
                 console.log("Flowchart data parsed and set to store from chat message.");
+              } else {
+                // Structured data was expected but not in the correct format
+                const formatError = "Flowchart data is missing nodes or edges.";
+                toast.error(`Error: ${formatError}`);
+                throw new Error(formatError);
               }
             } catch (e) {
-              console.error("Failed to parse structured data from chat message:", e);
-              // Keep original message text if parsing fails
+              const parseError = `Error processing flowchart: ${e instanceof Error ? e.message : 'Invalid format.'}`;
+              toast.error(parseError);
+              console.error("Failed to parse structured flowchart data:", e);
+              addMessage(currentExerciseId, {
+                id: Date.now().toString() + '-error',
+                sender: 'assistant',
+                text: parseError,
+                timestamp: Date.now(),
+              });
             }
+          } else if (command === 'generate') {
+            // Handle cases where /generate was called but response was not structured or failed
+            const generateError = "Failed to generate flowchart. The response was not as expected.";
+            toast.error(generateError);
+             addMessage(currentExerciseId, {
+                id: Date.now().toString() + '-generate-error',
+                sender: 'assistant',
+                text: botReply.text || generateError, // Show bot's text or a generic error
+                timestamp: Date.now(),
+            });
           }
-          addMessage(currentExerciseId, messageToStore);
+          else {
+            // Regular message or /learn response
+            addMessage(currentExerciseId, botReply);
+          }
         }
       } catch (error) {
+        const apiError = `API Error: ${error instanceof Error ? error.message : "Sorry, I couldn't connect to the assistant."}`;
+        toast.error(apiError);
         console.error("Error sending message to API:", error);
         if (currentExerciseId) {
             addMessage(currentExerciseId, {
                 id: Date.now().toString() + '-error',
                 sender: 'assistant',
-                text: "Sorry, I couldn't connect to the assistant. Please try again.",
+                text: apiError,
                 timestamp: Date.now(),
             });
         }
       } finally {
         setIsBotTyping(false);
+        if (command === 'generate') {
+          setIsGeneratingFlowchart(false); // Stop loading after API call attempt for /generate
+        }
       }
     }
   };

--- a/src/components/FlowchartBuilder.tsx
+++ b/src/components/FlowchartBuilder.tsx
@@ -41,6 +41,8 @@ interface FlowchartBuilderProps {
   onRunCode: (code: string) => void;
   isRunning: boolean;
   newFlowchartToLoad?: FlowchartData | null; // New prop for AI generated flowcharts
+  isGeneratingFlowchart?: boolean; // For spinner display
+  highlightedNodeId?: string | null; // Added from previous context, ensure it's used or removed if not
 }
 
 interface NodePalette {
@@ -109,7 +111,8 @@ export const FlowchartBuilder: React.FC<FlowchartBuilderProps> = ({
   onRunCode,
   isRunning,
   newFlowchartToLoad,
-  highlightedNodeId // This prop is from App.tsx for dry run, ensure it's declared in FlowchartBuilderProps if not already
+  isGeneratingFlowchart, // Destructure the new prop
+  highlightedNodeId
 }) => {
   const { currentUser } = useAuth(); // Get current user for presence updates
   const [flowchartData, setFlowchartData] = useState<FlowchartData>({
@@ -778,6 +781,12 @@ const selectedNodeDataForProperties = selectedNodeForProperties
             onClick={handleCanvasClick} // Added to handle clicks on canvas background
             // onMouseLeave={handleDragEnd} // Removed this line as it might prematurely end drags
           >
+            {isGeneratingFlowchart && (
+              <div className="absolute inset-0 bg-gray-500 bg-opacity-50 flex items-center justify-center z-50">
+                <div className="animate-spin rounded-full h-16 w-16 border-t-2 border-b-2 border-blue-500"></div>
+                <p className="ml-3 text-white font-semibold">Generating Flowchart...</p>
+              </div>
+            )}
             {/* Render Edges */}
             <svg className="absolute inset-0 w-full h-full pointer-events-none">
               {isConnecting && connectionStart && connectingMousePosition && (() => {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -2,6 +2,7 @@ import { ChatMessage, ExerciseContext } from '../store/chatStore';
 
 interface ApiChatRequest {
   message: string;
+  command?: 'chat' | 'learn' | 'generate'; // Added command field
   exerciseContext: { // Be more specific about what's needed from ExerciseContext
     currentExerciseId?: number | string | null; // Allow for flexible ID types
     title?: string | null;
@@ -55,6 +56,7 @@ export const postRealChatMessage = async (data: ApiChatRequest): Promise<Backend
     },
     body: JSON.stringify({
       message: data.message,
+      command: data.command || 'chat', // Pass the command, default to 'chat'
       exercise_id: data.exerciseContext?.currentExerciseId?.toString(), // Ensure it's a string for backend
       exercise_title: data.exerciseContext?.title,
     }),

--- a/src/store/chatStore.ts
+++ b/src/store/chatStore.ts
@@ -33,6 +33,10 @@ interface ChatState {
   setGeneratedFlowchartData: (data: FlowchartData | null) => void; // Setter for AI flowchart
   lastResyncRequested: number | null;
   requestResync: () => void;
+  isCheatModeSource: boolean; // Added for cheat mode tracking
+  setIsCheatModeSource: (isCheat: boolean) => void; // Added for cheat mode tracking
+  isGeneratingFlowchart: boolean; // For spinner
+  setIsGeneratingFlowchart: (isLoading: boolean) => void; // For spinner
 }
 
 const useChatStore = create<ChatState>()(
@@ -44,9 +48,13 @@ const useChatStore = create<ChatState>()(
       chatHistory: {},
       generatedFlowchartData: null, // Initialize
       lastResyncRequested: null,
+      isCheatModeSource: false, // Initialize cheat mode flag
+      isGeneratingFlowchart: false, // Initialize loading flag
       toggleVisibility: () => set((state) => ({ isVisible: !state.isVisible })),
       requestResync: () => set({ lastResyncRequested: Date.now() }),
       setGeneratedFlowchartData: (data) => set({ generatedFlowchartData: data }), // Implement setter
+      setIsCheatModeSource: (isCheat) => set({ isCheatModeSource: isCheat }), // Implement cheat mode setter
+      setIsGeneratingFlowchart: (isLoading) => set({ isGeneratingFlowchart: isLoading }), // Implement loading setter
       setExerciseContext: (context) =>
         set((state) => {
           // When context changes, update currentExerciseId


### PR DESCRIPTION
- Restored the /generate chat command pipeline:
  - Correctly parses `/generate <description>` and `/learn <topic>` commands.
  - Sends `command` and `message` fields to `POST /api/chat`.
  - Renders generated flowchart nodes/edges onto the canvas.
- Implemented cheat-mode logic for `/generate`:
  - Flowcharts generated via this command do not award progress points (XP, badges, etc.).
  - Uses a flag in chatStore (`isCheatModeSource`) to communicate this to App.tsx.
  - Other state (diagram, undo, save/load) remains functional.
- Added UX polish:
  - Non-blocking spinner overlay in canvas during flowchart generation.
  - Toast notification: "Flow-chart generated in cheat mode – progress not counted." on success.
  - Improved toast notifications for API and parsing errors.
- Ensured /learn command behavior is unaffected.
- Addressed bug where the `/generate` keyword was stripped before reaching the backend.